### PR TITLE
fix(ci): restore compatibility after refactor and unblock tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Thumbs.db
 test_*.json
 ground_truth_*.json
 queries_sample.json
+.ast_rag_summary_cache.json
 
 # Benchmark results (optional - uncomment to ignore)
 # benchmarks/results/*.json

--- a/ast_rag/api/ast_rag_api.py
+++ b/ast_rag/api/ast_rag_api.py
@@ -945,8 +945,8 @@ RETURN count(*) as count
         total = self._count_usages_of_node(node_id)
 
         # Query for incoming CALLS edges with pagination
-        calls_cypher = f"""
-MATCH (caller)-[r:CALLS]->(target {{id: $node_id}})
+        calls_cypher = """
+MATCH (caller)-[r:CALLS]->(target {id: $node_id})
 WHERE caller.valid_to IS NULL AND r.valid_to IS NULL
 RETURN caller, r
 ORDER BY caller.qualified_name
@@ -969,8 +969,8 @@ SKIP $offset LIMIT $limit
                 )
 
         # Query for incoming TYPES edges with pagination
-        types_cypher = f"""
-MATCH (user)-[r:TYPES]->(target {{id: $node_id}})
+        types_cypher = """
+MATCH (user)-[r:TYPES]->(target {id: $node_id})
 WHERE user.valid_to IS NULL AND r.valid_to IS NULL
 RETURN user, r
 ORDER BY user.qualified_name
@@ -993,8 +993,8 @@ SKIP $offset LIMIT $limit
                 )
 
         # Query for incoming INHERITS/EXTENDS/IMPLEMENTS edges with pagination
-        inherits_cypher = f"""
-MATCH (child)-[r:INHERITS|EXTENDS|IMPLEMENTS]->(parent {{id: $node_id}})
+        inherits_cypher = """
+MATCH (child)-[r:INHERITS|EXTENDS|IMPLEMENTS]->(parent {id: $node_id})
 WHERE child.valid_to IS NULL AND r.valid_to IS NULL
 RETURN child, r, type(r) as rel_type
 ORDER BY child.qualified_name
@@ -1214,7 +1214,7 @@ SKIP $offset LIMIT $limit
         Returns:
             List of block dictionaries with full details
         """
-        type_filter = f"AND b.block_type = $block_type" if block_type else ""
+        type_filter = "AND b.block_type = $block_type" if block_type else ""
 
         cypher = f"""
 MATCH (f)-[r:CONTAINS_BLOCK]->(b:Block)

--- a/ast_rag/ast_rag_api.py
+++ b/ast_rag/ast_rag_api.py
@@ -1,0 +1,3 @@
+"""Compatibility shim for the legacy API module path."""
+
+from ast_rag.api.ast_rag_api import *  # noqa: F403

--- a/ast_rag/ast_rag_mcp.py
+++ b/ast_rag/ast_rag_mcp.py
@@ -1,0 +1,4 @@
+"""Compatibility shim for the legacy MCP module path."""
+
+from ast_rag.mcp.server import *  # noqa: F403
+from ast_rag.mcp.server import main  # noqa: F401

--- a/ast_rag/cli.py
+++ b/ast_rag/cli.py
@@ -164,7 +164,7 @@ def init(
             )
 
             with driver.session() as session:
-                batch_upsert_blocks(session, all_blocks, commit_hash)
+                batch_upsert_blocks(session, all_blocks, commit)
                 batch_upsert_block_edges(session, all_block_edges)
             console.print(
                 f"[green]Stored {len(all_blocks)} blocks and {len(all_block_edges)} CONTAINS_BLOCK edges.[/green]"
@@ -1051,7 +1051,7 @@ def index_folder(
     # Set project root for subprocess
     os.environ["AST_RAG_PROJECT_ROOT"] = str(Path(__file__).parent.parent.parent)
 
-    from ast_rag.services.parsing.parser_manager import ParserManager, EXT_TO_LANG
+    from ast_rag.services.parsing.parser_manager import EXT_TO_LANG
     from ast_rag.repositories import create_driver, apply_schema
     from ast_rag.services.graph_updater_service import (
         _nodes_to_batch_by_label,
@@ -1302,7 +1302,7 @@ def blocks(
             if source:
                 source_code = api.get_block_source(block["id"])
                 if source_code:
-                    console.print(f"   [dim]Source:[/dim]")
+                    console.print("   [dim]Source:[/dim]")
                     for line in source_code.split("\n")[:5]:  # Show first 5 lines
                         console.print(f"     [dim]{line}[/dim]")
                     if len(source_code.split("\n")) > 5:
@@ -1380,179 +1380,6 @@ def list_lambdas(
             console.print()
     else:
         print(json.dumps(lambdas, indent=2))
-
-
-# ---------------------------------------------------------------------------
-# analyze-stacktrace command
-# ---------------------------------------------------------------------------
-
-
-@app.command("analyze-stacktrace")
-def analyze_stacktrace(
-    input_path: Optional[str] = typer.Argument(
-        None,
-        help="Path to file containing stack trace. If not provided, reads from stdin.",
-    ),
-    config: Optional[str] = typer.Option(
-        None,
-        "--config",
-        "-c",
-        help="Path to config JSON file",
-    ),
-    output: str = typer.Option(
-        "markdown",
-        "--output",
-        "-o",
-        help="Output format: markdown, json, text",
-    ),
-    verbose: bool = typer.Option(
-        False,
-        "--verbose",
-        "-v",
-        help="Enable verbose logging",
-    ),
-    no_ast_mapping: bool = typer.Option(
-        False,
-        "--no-ast-mapping",
-        help="Skip AST node mapping (faster, less context)",
-    ),
-    limit_similar: int = typer.Option(
-        5,
-        "--limit-similar",
-        "-n",
-        help="Maximum number of similar issues to find",
-    ),
-) -> None:
-    """
-    Analyze a stack trace and map it to code with context.
-
-    This command parses stack traces from Python, C++, Java, or Rust,
-    maps each frame to AST nodes, retrieves code snippets, and provides
-    root cause analysis with suggested fixes.
-
-    **Input:**
-
-    Reads stack trace from:
-    - File path (if provided as argument)
-    - Standard input (if no argument)
-
-    **Supported Formats:**
-
-    - **Python:** File "x.py", line 42, in func
-    - **C++:** #0 0x... in func() at file.cpp:42
-    - **Java:** at com.example.Class.method(Class.java:42)
-    - **Rust:** at src/file.rs:42
-
-    **Output:**
-
-    Generates a StackTraceReport with:
-    - Parsed call chain with frame details
-    - Root cause analysis and severity
-    - Code snippets for each frame
-    - Suggested fixes
-    - Similar issues from codebase
-
-    **Examples:**
-
-      # Read from stdin (paste stack trace, then Ctrl+D)
-      ast-rag analyze-stacktrace
-
-      # Read from file
-      ast-rag analyze-stacktrace error.log
-
-      # Output as JSON
-      ast-rag analyze-stacktrace error.log -o json
-
-      # Skip AST mapping for faster analysis
-      ast-rag analyze-stacktrace error.log --no-ast-mapping
-
-      # Pipe from another command
-      python test.py 2>&1 | ast-rag analyze-stacktrace
-    """
-    if verbose:
-        logging.basicConfig(level=logging.DEBUG)
-    else:
-        logging.basicConfig(level=logging.WARNING)
-
-    # Read stack trace
-    if input_path:
-        try:
-            stacktrace = Path(input_path).read_text(encoding="utf-8", errors="replace")
-        except FileNotFoundError:
-            console.print(f"[red]File not found: {input_path}[/red]")
-            raise typer.Exit(1)
-        except OSError as e:
-            console.print(f"[red]Error reading file: {e}[/red]")
-            raise typer.Exit(1)
-    else:
-        # Read from stdin
-        console.print("[yellow]Reading stack trace from stdin (paste then Ctrl+D)...[/yellow]")
-        import sys
-
-        stacktrace = sys.stdin.read()
-
-    if not stacktrace.strip():
-        console.print("[red]Empty stack trace provided[/red]")
-        raise typer.Exit(1)
-
-    # Load config and initialize service
-    cfg = _load_config(config)
-
-    try:
-        driver = create_driver(cfg.neo4j)
-        embed = EmbeddingManager(cfg.qdrant, cfg.embedding, neo4j_driver=driver)
-
-        from ast_rag.stack_trace import StackTraceService
-
-        service = StackTraceService(
-            driver=driver,
-            embedding_manager=embed,
-            codebase_root=os.getcwd(),
-        )
-
-        # Analyze stack trace
-        with console.status("[bold blue]Analyzing stack trace...[/bold blue]"):
-            report = service.analyze(stacktrace)
-
-        # Output results
-        console.print()
-
-        if output == "json":
-            print(report.to_json(indent=2))
-        elif output == "text":
-            console.print(report.summary or "No summary available")
-            console.print()
-            if report.root_cause:
-                rc = report.root_cause
-                console.print(f"[bold]Error Type:[/bold] {rc.error_type}")
-                console.print(f"[bold]Category:[/bold] {rc.category or 'unknown'}")
-                console.print(f"[bold]Severity:[/bold] {rc.severity}")
-                console.print(f"[bold]Confidence:[/bold] {rc.confidence:.0%}")
-                if rc.likely_cause:
-                    console.print(f"[bold]Likely Cause:[/bold] {rc.likely_cause}")
-                if rc.suggested_fix:
-                    console.print(f"[bold]Suggested Fix:[/bold]")
-                    console.print(rc.suggested_fix)
-        else:  # markdown
-            console.print(report.to_markdown())
-
-        # Show stats
-        console.print()
-        console.print(
-            f"[dim]Parsed {report.total_frames} frames, mapped {report.mapped_frames} to AST[/dim]"
-        )
-        if report.similar_issues:
-            console.print(f"[dim]Found {len(report.similar_issues)} similar issues[/dim]")
-
-        driver.close()
-
-    except Exception as e:
-        console.print(f"[red]Error analyzing stack trace: {e}[/red]")
-        if verbose:
-            import traceback
-
-            console.print(traceback.format_exc())
-        raise typer.Exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -1875,7 +1702,7 @@ def analyze_stacktrace(
                 if rc.likely_cause:
                     console.print(f"[bold]Likely Cause:[/bold] {rc.likely_cause}")
                 if rc.suggested_fix:
-                    console.print(f"[bold]Suggested Fix:[/bold]")
+                    console.print("[bold]Suggested Fix:[/bold]")
                     console.print(rc.suggested_fix)
         else:  # markdown
             console.print(report.to_markdown())

--- a/ast_rag/dto/block.py
+++ b/ast_rag/dto/block.py
@@ -38,6 +38,7 @@ class ASTBlock(BaseModel):
         valid_from: Version when this block was added
         valid_to: Version when this block was deleted
     """
+
     id: str = Field(default="", description="Stable SHA-256 based identifier")
     block_type: BlockType
     name: str = Field(default="", description="Optional name")
@@ -85,9 +86,10 @@ class ASTBlock(BaseModel):
             "valid_to": self.valid_to,
         }
 
-    def to_standard_result(self, score: Optional[float] = None) -> "StandardResult":
+    def to_standard_result(self, score: Optional[float] = None) -> "StandardResult":  # noqa: F821
         """Convert ASTBlock to StandardResult."""
         from ast_rag.dto.result import StandardResult
+
         return StandardResult(
             id=self.id,
             name=self.name or f"{self.block_type.value}_block",

--- a/ast_rag/dto/config.py
+++ b/ast_rag/dto/config.py
@@ -20,6 +20,7 @@ class Neo4jConfig(BaseModel):
         database: Database name (Community Edition: always "neo4j")
         project_id: Project identifier for data isolation (prefix-based)
     """
+
     uri: str = "bolt://localhost:7687"
     user: str = "neo4j"
     password: str = "password"
@@ -35,6 +36,7 @@ class QdrantConfig(BaseModel):
         collection_name: Collection name for embeddings
         local_path: If set, use local file mode instead of server
     """
+
     url: str = "http://localhost:6333"
     collection_name: str = "ast_rag_nodes"
     local_path: Optional[str] = None
@@ -53,6 +55,7 @@ class EmbeddingConfig(BaseModel):
         vector_weight: Weight for vector similarity scores
         keyword_weight: Weight for keyword search scores
     """
+
     model_name: str = "BAAI/bge-m3"
     device: str = "cpu"
     remote_url: Optional[str] = None
@@ -73,6 +76,7 @@ class ProjectConfig(BaseModel):
         language_extensions: File extensions per language
         exclude_patterns: Patterns to exclude during indexing
     """
+
     neo4j: Neo4jConfig = Field(default_factory=Neo4jConfig)
     qdrant: QdrantConfig = Field(default_factory=QdrantConfig)
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
@@ -87,7 +91,16 @@ class ProjectConfig(BaseModel):
     )
     exclude_patterns: list[str] = Field(
         default_factory=lambda: [
-            ".git", "__pycache__", "node_modules", "target", "build", "dist",
-            ".gradle", ".idea", ".vscode", "venv", ".venv",
+            ".git",
+            "__pycache__",
+            "node_modules",
+            "target",
+            "build",
+            "dist",
+            ".gradle",
+            ".idea",
+            ".vscode",
+            "venv",
+            ".venv",
         ]
     )

--- a/ast_rag/dto/enums.py
+++ b/ast_rag/dto/enums.py
@@ -14,29 +14,31 @@ from enum import Enum
 
 class NodeKind(str, Enum):
     """All recognised AST node kinds persisted in the graph."""
+
     PROJECT = "Project"
-    PACKAGE = "Package"        # Java package / Python module dir
-    NAMESPACE = "Namespace"    # C++ namespace
-    MODULE = "Module"          # Python module file / Rust module
+    PACKAGE = "Package"  # Java package / Python module dir
+    NAMESPACE = "Namespace"  # C++ namespace
+    MODULE = "Module"  # Python module file / Rust module
     FILE = "File"
     CLASS = "Class"
-    INTERFACE = "Interface"    # Java interface
-    STRUCT = "Struct"          # C++ struct / Rust struct
+    INTERFACE = "Interface"  # Java interface
+    STRUCT = "Struct"  # C++ struct / Rust struct
     ENUM = "Enum"
-    TRAIT = "Trait"            # Rust trait
-    FUNCTION = "Function"      # top-level / free function
-    METHOD = "Method"          # class member function
+    TRAIT = "Trait"  # Rust trait
+    FUNCTION = "Function"  # top-level / free function
+    METHOD = "Method"  # class member function
     CONSTRUCTOR = "Constructor"
     DESTRUCTOR = "Destructor"  # C++
-    FIELD = "Field"            # class member field
+    FIELD = "Field"  # class member field
     VARIABLE = "Variable"
     PARAMETER = "Parameter"
-    BLOCK = "Block"            # Code block (if/for/while/try/lambda/with)
+    BLOCK = "Block"  # Code block (if/for/while/try/lambda/with)
     CURRENT_VERSION = "CurrentVersion"
 
 
 class EdgeKind(str, Enum):
     """All edge types in the graph."""
+
     CONTAINS_PACKAGE = "CONTAINS_PACKAGE"
     CONTAINS_FILE = "CONTAINS_FILE"
     CONTAINS_CLASS = "CONTAINS_CLASS"
@@ -45,13 +47,13 @@ class EdgeKind(str, Enum):
     CONTAINS_FIELD = "CONTAINS_FIELD"
     CONTAINS_BLOCK = "CONTAINS_BLOCK"  # Function contains block
     HAS_PARAMETER = "HAS_PARAMETER"
-    IMPORTS = "IMPORTS"      # Java / Python / TS import
-    INCLUDES = "INCLUDES"    # C++ #include
+    IMPORTS = "IMPORTS"  # Java / Python / TS import
+    INCLUDES = "INCLUDES"  # C++ #include
     CALLS = "CALLS"
-    INHERITS = "INHERITS"    # C++ inheritance
-    EXTENDS = "EXTENDS"      # Java extends
+    INHERITS = "INHERITS"  # C++ inheritance
+    EXTENDS = "EXTENDS"  # Java extends
     IMPLEMENTS = "IMPLEMENTS"
-    INJECTS = "INJECTS"      # DI heuristic: field of another class type
+    INJECTS = "INJECTS"  # DI heuristic: field of another class type
     OVERRIDES = "OVERRIDES"
     DEPENDS_ON = "DEPENDS_ON"
     TYPES = "TYPES"
@@ -62,6 +64,7 @@ class EdgeKind(str, Enum):
 
 class Language(str, Enum):
     """Supported source languages."""
+
     CPP = "cpp"
     JAVA = "java"
     RUST = "rust"
@@ -71,12 +74,13 @@ class Language(str, Enum):
 
 class BlockType(str, Enum):
     """Types of code blocks that can be extracted."""
+
     IF = "if"
     FOR = "for"
     WHILE = "while"
     TRY = "try"
     LAMBDA = "lambda"
     WITH = "with"
-    MATCH = "match"        # Rust match, Python match (3.10+)
-    SWITCH = "switch"      # C++/Java/TS switch
-    LOOP = "loop"          # Rust loop
+    MATCH = "match"  # Rust match, Python match (3.10+)
+    SWITCH = "switch"  # C++/Java/TS switch
+    LOOP = "loop"  # Rust loop

--- a/ast_rag/dto/node.py
+++ b/ast_rag/dto/node.py
@@ -38,6 +38,7 @@ class ASTNode(BaseModel):
         valid_to: Version when this node was deleted (None = current)
         source_text: Raw source text (not persisted to graph)
     """
+
     id: str = Field(default="", description="Stable SHA-256 based identifier")
     kind: NodeKind
     name: str
@@ -86,9 +87,12 @@ class ASTNode(BaseModel):
             "valid_to": self.valid_to,
         }
 
-    def to_standard_result(self, score: Optional[float] = None, edge_type: Optional[str] = None) -> "StandardResult":
+    def to_standard_result(
+        self, score: Optional[float] = None, edge_type: Optional[str] = None
+    ) -> "StandardResult":  # noqa: F821
         """Convert ASTNode to StandardResult."""
         from ast_rag.dto.result import StandardResult
+
         return StandardResult(
             id=self.id,
             name=self.name,
@@ -120,6 +124,7 @@ class ASTEdge(BaseModel):
         raw_type_string: Original type annotation for TYPES edges
         confidence: Certainty score for OVERRIDES edges
     """
+
     id: str = Field(default="", description="Stable edge identifier")
     kind: EdgeKind
     from_id: str

--- a/ast_rag/dto/result.py
+++ b/ast_rag/dto/result.py
@@ -10,7 +10,6 @@ from typing import Optional
 from pydantic import BaseModel, Field
 
 from ast_rag.dto.node import ASTNode, ASTEdge
-from ast_rag.dto.block import ASTBlock
 
 
 class DiffResult(BaseModel):
@@ -26,6 +25,7 @@ class DiffResult(BaseModel):
         updated_edges: New versions of updated edges
         old_updated_edge_ids: Old IDs of updated edges to expire
     """
+
     added_nodes: list[ASTNode] = Field(default_factory=list)
     deleted_node_ids: list[str] = Field(default_factory=list)
     updated_nodes: list[ASTNode] = Field(default_factory=list)
@@ -55,6 +55,7 @@ class SubGraph(BaseModel):
         nodes: List of AST nodes in the subgraph
         edges: List of edges connecting the nodes
     """
+
     nodes: list[ASTNode] = Field(default_factory=list)
     edges: list[ASTEdge] = Field(default_factory=list)
 
@@ -66,6 +67,7 @@ class SearchResult(BaseModel):
         node: The matched AST node
         score: Relevance score (0.0-1.0)
     """
+
     node: ASTNode
     score: float
 
@@ -93,6 +95,7 @@ class StandardResult(BaseModel):
         edge_type: Edge type for reference results
         metadata: Extra fields (confidence, raw_type_string, etc.)
     """
+
     id: str
     name: str
     qualified_name: str

--- a/ast_rag/graph_updater.py
+++ b/ast_rag/graph_updater.py
@@ -1,0 +1,3 @@
+"""Compatibility shim for the legacy graph updater module path."""
+
+from ast_rag.services.graph_updater_service import *  # noqa: F403

--- a/ast_rag/language_queries.py
+++ b/ast_rag/language_queries.py
@@ -1,0 +1,10 @@
+"""Compatibility shim for the legacy language query module path."""
+
+from ast_rag.services.parsing import (  # noqa: F401
+    CPP_QUERIES,
+    JAVA_QUERIES,
+    LANGUAGE_QUERIES,
+    PYTHON_QUERIES,
+    RUST_QUERIES,
+    TYPESCRIPT_QUERIES,
+)

--- a/ast_rag/parse_cache.py
+++ b/ast_rag/parse_cache.py
@@ -1,0 +1,3 @@
+"""Compatibility shim for the legacy parse cache module path."""
+
+from ast_rag.utils.parse_cache import *  # noqa: F403

--- a/ast_rag/repositories/neo4j_repository.py
+++ b/ast_rag/repositories/neo4j_repository.py
@@ -17,7 +17,7 @@ import logging
 from typing import Any, Optional
 from collections.abc import Iterable
 
-from neo4j import Driver, GraphDatabase, Session, Result
+from neo4j import Driver, GraphDatabase, Result
 
 from ast_rag.dto import ASTNode, ASTEdge, Neo4jConfig
 
@@ -35,11 +35,11 @@ class Neo4jRepository:
 
         config = Neo4jConfig(uri="bolt://localhost:7687", user="neo4j", password="password")
         repo = Neo4jRepository(config)
-        
+
         # Create a node
         node = ASTNode(...)
         repo.create_node(node)
-        
+
         # Query nodes
         results = repo.execute_query("MATCH (n:Function) RETURN n LIMIT 10")
 
@@ -775,7 +775,6 @@ ON (n.{property_name})
             if_not_exists: If True, skip if index already exists
         """
         if_not_exists_clause = "IF NOT EXISTS" if if_not_exists else ""
-        labels_str = ", ".join([f"`{l}`" for l in labels])
         props_str = ", ".join([f"n.{p}" for p in properties])
         query = f"""
 CREATE FULLTEXT INDEX {index_name} {if_not_exists_clause}

--- a/ast_rag/repositories/qdrant_repository.py
+++ b/ast_rag/repositories/qdrant_repository.py
@@ -21,17 +21,12 @@ from qdrant_client.models import (
     Distance,
     VectorParams,
     PointStruct,
-    PointIdsList,
     Filter,
     FieldCondition,
-    MatchValue,
-    MatchText,
-    Range,
-    SearchParams,
     ScoredPoint,
 )
 
-from ast_rag.dto import QdrantConfig, SearchResult, ASTNode
+from ast_rag.dto import QdrantConfig, SearchResult
 
 
 class QdrantRepository:
@@ -45,11 +40,11 @@ class QdrantRepository:
 
         config = QdrantConfig(url="http://localhost:6333", collection_name="ast_rag")
         repo = QdrantRepository(config)
-        
+
         # Upsert points
         points = [PointStruct(id=1, vector=[...], payload={...})]
         repo.upsert_points(points)
-        
+
         # Search
         results = repo.search_vectors(query_vector=[...], limit=10)
 
@@ -139,7 +134,7 @@ class QdrantRepository:
     def get_collection_info(
         self,
         collection_name: Optional[str] = None,
-    ) -> Optional[CollectionInfo]:
+    ) -> "Optional[CollectionInfo]":  # noqa: F821
         """Get information about a collection.
 
         Args:

--- a/ast_rag/repositories/queries.py
+++ b/ast_rag/repositories/queries.py
@@ -1,0 +1,93 @@
+"""
+Repository query helpers for the MVCC graph updater.
+
+These helpers were split out during refactoring and are still imported by
+``graph_updater_service``. Restoring them keeps the current architecture intact
+without changing the graph updater call sites.
+"""
+
+from __future__ import annotations
+
+from neo4j import Session
+
+
+def batch_upsert_nodes(session: Session, by_label: dict[str, list[dict]]) -> None:
+    """MERGE nodes grouped by label."""
+    for label, props_list in by_label.items():
+        if not props_list:
+            continue
+        session.run(
+            f"""
+            UNWIND $props AS p
+            MERGE (n:{label} {{id: p.id}})
+            SET n += p
+            """,
+            props=props_list,
+        )
+
+
+def batch_expire_nodes(
+    session: Session,
+    by_label: dict[str, list[str]],
+    commit_hash: str,
+) -> None:
+    """Set ``valid_to`` on nodes to mark them expired."""
+    for label, ids in by_label.items():
+        if not ids:
+            continue
+        session.run(
+            f"""
+            UNWIND $ids AS nid
+            MATCH (n:{label} {{id: nid}})
+            WHERE n.valid_to IS NULL
+            SET n.valid_to = $commit_hash
+            """,
+            ids=ids,
+            commit_hash=commit_hash,
+        )
+
+
+def batch_upsert_edges(session: Session, edge_dicts: list[dict]) -> None:
+    """MERGE edges keyed by ``id``."""
+    if not edge_dicts:
+        return
+    session.run(
+        """
+        UNWIND $edges AS e
+        MATCH (a {id: e.from_id}), (b {id: e.to_id})
+        MERGE (a)-[r:EDGE {id: e.id}]->(b)
+        SET r += e
+        """,
+        edges=edge_dicts,
+    )
+
+
+def batch_expire_edges(
+    session: Session,
+    edge_ids: list[str],
+    commit_hash: str,
+) -> None:
+    """Set ``valid_to`` on edges to mark them expired."""
+    if not edge_ids:
+        return
+    session.run(
+        """
+        UNWIND $ids AS eid
+        MATCH ()-[r:EDGE {id: eid}]->()
+        WHERE r.valid_to IS NULL
+        SET r.valid_to = $commit_hash
+        """,
+        ids=edge_ids,
+        commit_hash=commit_hash,
+    )
+
+
+def ensure_current_version(session: Session, commit_hash: str) -> None:
+    """Create or update the ``CurrentVersion`` singleton node."""
+    session.run(
+        """
+        MERGE (v:CurrentVersion {id: 'current'})
+        SET v.commit_hash = $commit_hash
+        """,
+        commit_hash=commit_hash,
+    )

--- a/ast_rag/repositories/schema_manager.py
+++ b/ast_rag/repositories/schema_manager.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 from typing import Any, Optional, List
 
-from neo4j import Driver, Session, Result
+from neo4j import Driver, Result
 
 from ast_rag.dto import Neo4jConfig
 
@@ -221,7 +221,7 @@ class SchemaManager:
 
         query_parts = [
             "CREATE INDEX",
-            f"IF NOT EXISTS" if if_not_exists else "",
+            "IF NOT EXISTS" if if_not_exists else "",
             f"{index_name}",
             f"FOR (n:{label})",
             f"ON (n.{property_name})",
@@ -280,11 +280,11 @@ class SchemaManager:
 
         query_parts = [
             "CREATE FULLTEXT INDEX",
-            f"IF NOT EXISTS" if if_not_exists else "",
+            "IF NOT EXISTS" if if_not_exists else "",
             f"{index_name}",
-            f"FOR",
+            "FOR",
             f"([{label_filters}])",
-            f"ON EACH",
+            "ON EACH",
             f"[{properties_str}]",
             f"OPTIONS {{ analyzer: '{analyzer}' }}",
         ]
@@ -348,7 +348,7 @@ class SchemaManager:
         Returns:
             True if index was dropped, False if it didn't exist
         """
-        query_parts = ["DROP INDEX", f"IF EXISTS" if if_exists else "", f"{index_name}"]
+        query_parts = ["DROP INDEX", "IF EXISTS" if if_exists else "", f"{index_name}"]
         query = " ".join(part for part in query_parts if part)
 
         try:
@@ -395,7 +395,6 @@ class SchemaManager:
                         "indexPopulation": record.get("indexPopulation"),
                         "entityType": record.get("entityType"),
                         "labelsOrTypes": record.get("labelsOrTypes"),
-                        "properties": record.get("properties"),
                     }
                 )
             return indexes
@@ -505,7 +504,7 @@ class SchemaManager:
         """
         query_parts = [
             "CREATE CONSTRAINT",
-            f"IF NOT EXISTS" if if_not_exists else "",
+            "IF NOT EXISTS" if if_not_exists else "",
             f"{constraint_name}",
             f"FOR (n:{label})",
             f"REQUIRE n.{property_name}",
@@ -542,7 +541,7 @@ class SchemaManager:
         Returns:
             True if constraint was dropped, False if it didn't exist
         """
-        query_parts = ["DROP CONSTRAINT", f"IF EXISTS" if if_exists else "", f"{constraint_name}"]
+        query_parts = ["DROP CONSTRAINT", "IF EXISTS" if if_exists else "", f"{constraint_name}"]
         query = " ".join(part for part in query_parts if part)
 
         try:
@@ -753,14 +752,8 @@ class SchemaManager:
             - indexes: List of index metadata
             - constraints: List of constraint metadata
         """
-        with self._driver.session() as session:
+        with self._driver.session() as _session:
             # Get node labels and counts
-            label_query = """
-            CALL db.labels() YIELD label
-            CALL apoc.cypher.run('MATCH (n:`' + label + '`) RETURN count(n) AS count', {}) YIELD value
-            RETURN label, value.count AS count
-            """
-            # Since we don't know if apoc is available, we'll do it differently
             labels_query = "CALL db.labels() YIELD label RETURN label"
             label_counts = {}
             for record in self._driver.session().run(labels_query):

--- a/ast_rag/sandbox/__init__.py
+++ b/ast_rag/sandbox/__init__.py
@@ -27,28 +27,28 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 DEFAULT_COMMANDS: dict[str, str] = {
-    "java":       "mvn test -B --no-transfer-progress",
-    "cpp":        "cmake --build /workspace/build && cd /workspace/build && ctest --output-on-failure",
-    "rust":       "cargo test",
-    "python":     "pytest --tb=short -q",
+    "java": "mvn test -B --no-transfer-progress",
+    "cpp": "cmake --build /workspace/build && cd /workspace/build && ctest --output-on-failure",
+    "rust": "cargo test",
+    "python": "pytest --tb=short -q",
     "typescript": "npm test",
 }
 
 # Docker images to use per language
 # NOTE: these are public Docker Hub images; pin versions in production.
 _DOCKER_IMAGES: dict[str, str] = {
-    "java":       "maven:3.9-eclipse-temurin-21",
-    "cpp":        "gcc:13",
-    "rust":       "rust:1.76",
-    "python":     "python:3.12-slim",
+    "java": "maven:3.9-eclipse-temurin-21",
+    "cpp": "gcc:13",
+    "rust": "rust:1.76",
+    "python": "python:3.12-slim",
     "typescript": "node:20-slim",
 }
 
 # Resource constraints
-_MEM_LIMIT = "512m"    # maximum RAM per container
+_MEM_LIMIT = "512m"  # maximum RAM per container
 _CPU_PERIOD = 100_000  # microseconds
-_CPU_QUOTA  = 50_000   # 0.5 CPU cores
-_TIMEOUT    = 300      # seconds before we kill the container
+_CPU_QUOTA = 50_000  # 0.5 CPU cores
+_TIMEOUT = 300  # seconds before we kill the container
 
 
 def run_in_sandbox(
@@ -89,7 +89,9 @@ def run_in_sandbox(
 
     client = docker.from_env()
 
-    logger.info("Sandbox: lang=%s image=%s command=%r workdir=%s", lang, image, command, abs_workdir)
+    logger.info(
+        "Sandbox: lang=%s image=%s command=%r workdir=%s", lang, image, command, abs_workdir
+    )
 
     try:
         container = client.containers.run(
@@ -122,8 +124,11 @@ def run_in_sandbox(
 
     except docker.errors.ContainerError as exc:
         # Non-zero exit code
-        stdout_text = exc.container.logs(stdout=True, stderr=False).decode("utf-8", errors="replace") \
-            if exc.container else ""
+        stdout_text = (
+            exc.container.logs(stdout=True, stderr=False).decode("utf-8", errors="replace")
+            if exc.container
+            else ""
+        )
         stderr_text = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else str(exc)
         return stdout_text, stderr_text, exc.exit_status
 

--- a/ast_rag/services/config.py
+++ b/ast_rag/services/config.py
@@ -24,6 +24,7 @@ class LLMConfig:
         max_tokens: Maximum tokens in response
         timeout: Request timeout in seconds
     """
+
     url: Optional[str] = None
     model: str = "qwen2.5-coder:14b"
     temperature: float = 0.1
@@ -54,6 +55,7 @@ class ServiceConfig:
         ...     llm_url="http://localhost:11434/v1"
         ... )
     """
+
     # Neo4j configuration
     neo4j_uri: str = "bolt://localhost:7687"
     neo4j_user: str = "neo4j"
@@ -84,10 +86,21 @@ class ServiceConfig:
     llm_timeout: int = 120
 
     # Indexing configuration
-    exclude_patterns: list[str] = field(default_factory=lambda: [
-        ".git", "__pycache__", "node_modules", "target", "build", "dist",
-        ".gradle", ".idea", ".vscode", "venv", ".venv",
-    ])
+    exclude_patterns: list[str] = field(
+        default_factory=lambda: [
+            ".git",
+            "__pycache__",
+            "node_modules",
+            "target",
+            "build",
+            "dist",
+            ".gradle",
+            ".idea",
+            ".vscode",
+            "venv",
+            ".venv",
+        ]
+    )
 
     def to_neo4j_config(self) -> Neo4jConfig:
         """Convert to Neo4jConfig."""
@@ -165,11 +178,9 @@ class ServiceConfig:
             neo4j_password=neo4j.get("password", "password"),
             neo4j_timeout=neo4j.get("connection_timeout", 30),
             neo4j_max_pool_size=neo4j.get("max_connection_pool_size", 50),
-
             qdrant_url=qdrant.get("url", "http://localhost:6333"),
             qdrant_collection=qdrant.get("collection_name", "ast_rag_nodes"),
             qdrant_timeout=qdrant.get("timeout", 60),
-
             embedding_model=embedding.get("model_name", "BAAI/bge-m3"),
             embedding_remote_url=embedding.get("remote_url"),
             embedding_remote_batch_size=embedding.get("remote_batch_size", 32),

--- a/ast_rag/services/embedding_manager.py
+++ b/ast_rag/services/embedding_manager.py
@@ -42,11 +42,19 @@ from ast_rag.models import ASTNode, SearchResult, QdrantConfig, EmbeddingConfig,
 logger = logging.getLogger(__name__)
 
 # Node kinds that are worth embedding (ignore field-level noise)
-EMBEDDABLE_KINDS = frozenset([
-    NodeKind.CLASS, NodeKind.INTERFACE, NodeKind.STRUCT, NodeKind.ENUM,
-    NodeKind.TRAIT, NodeKind.FUNCTION, NodeKind.METHOD,
-    NodeKind.CONSTRUCTOR, NodeKind.DESTRUCTOR,
-])
+EMBEDDABLE_KINDS = frozenset(
+    [
+        NodeKind.CLASS,
+        NodeKind.INTERFACE,
+        NodeKind.STRUCT,
+        NodeKind.ENUM,
+        NodeKind.TRAIT,
+        NodeKind.FUNCTION,
+        NodeKind.METHOD,
+        NodeKind.CONSTRUCTOR,
+        NodeKind.DESTRUCTOR,
+    ]
+)
 
 
 def build_summary(node: ASTNode) -> str:
@@ -95,7 +103,7 @@ class EmbeddingManager:
                 logger.warning(
                     "Hybrid weights sum to %.2f (expected ~1.0). "
                     "Consider adjusting vector_weight and keyword_weight.",
-                    total
+                    total,
                 )
 
     # ------------------------------------------------------------------
@@ -105,8 +113,11 @@ class EmbeddingManager:
     def _get_model(self) -> SentenceTransformer:
         """Return local SentenceTransformer.  Not called when remote_url is set."""
         if self._model is None:
-            logger.info("Loading embedding model locally: %s (device=%s)",
-                        self._embed_config.model_name, self._embed_config.device)
+            logger.info(
+                "Loading embedding model locally: %s (device=%s)",
+                self._embed_config.model_name,
+                self._embed_config.device,
+            )
             self._model = SentenceTransformer(
                 self._embed_config.model_name,
                 device=self._embed_config.device,
@@ -160,7 +171,8 @@ class EmbeddingManager:
         if len(texts) > batch_size:
             logger.debug(
                 "Sub-batching %d texts into chunks of %d for remote encoding",
-                len(texts), batch_size,
+                len(texts),
+                batch_size,
             )
             parts: list[np.ndarray] = []
             for i in range(0, len(texts), batch_size):
@@ -365,13 +377,9 @@ class EmbeddingManager:
 
         must_conditions = []
         if lang_filter:
-            must_conditions.append(
-                FieldCondition(key="lang", match=MatchValue(value=lang_filter))
-            )
+            must_conditions.append(FieldCondition(key="lang", match=MatchValue(value=lang_filter)))
         if kind_filter:
-            must_conditions.append(
-                FieldCondition(key="kind", match=MatchValue(value=kind_filter))
-            )
+            must_conditions.append(FieldCondition(key="kind", match=MatchValue(value=kind_filter)))
 
         query_filter = Filter(must=must_conditions) if must_conditions else None
 
@@ -400,9 +408,12 @@ class EmbeddingManager:
             logger.debug(
                 "Only %d results with filters (lang=%s, kind=%s), "
                 "searching across all languages for %d more",
-                len(results), lang_filter, kind_filter, remaining
+                len(results),
+                lang_filter,
+                kind_filter,
+                remaining,
             )
-            
+
             # Search without language filter to fill remaining
             fallback_response = client.query_points(
                 collection_name=name,
@@ -411,7 +422,7 @@ class EmbeddingManager:
                 limit=remaining,
                 with_payload=True,
             )
-            
+
             for hit in fallback_response.points:
                 node = _payload_to_node(hit.payload or {})
                 # Avoid duplicates
@@ -473,7 +484,8 @@ class EmbeddingManager:
         # Build Cypher query for full-text search
         lang_clause = "AND node.lang = $lang" if lang_filter else ""
 
-        cypher = """
+        cypher = (
+            """
 CALL db.index.fulltext.queryNodes(
     'ast_symbol_fulltext',
     $search_query,
@@ -481,10 +493,13 @@ CALL db.index.fulltext.queryNodes(
 )
 YIELD node, score
 WHERE node.valid_to IS NULL
-  """ + lang_clause + """
+  """
+            + lang_clause
+            + """
 RETURN node, score
 ORDER BY score DESC
 """
+        )
         params: dict = {
             "search_query": query,
             "limit": limit,
@@ -580,11 +595,17 @@ ORDER BY score DESC
         # Build lookup dicts: node_id -> (node, normalized_score)
         vector_dict: dict[str, tuple[ASTNode, float]] = {}
         for i, r in enumerate(vector_results):
-            vector_dict[r.node.id] = (r.node, normalized_vector_scores[i] if i < len(normalized_vector_scores) else 0.0)
+            vector_dict[r.node.id] = (
+                r.node,
+                normalized_vector_scores[i] if i < len(normalized_vector_scores) else 0.0,
+            )
 
         keyword_dict: dict[str, tuple[ASTNode, float]] = {}
         for i, (node, score) in enumerate(keyword_results):
-            keyword_dict[node.id] = (node, normalized_keyword_scores[i] if i < len(normalized_keyword_scores) else 0.0)
+            keyword_dict[node.id] = (
+                node,
+                normalized_keyword_scores[i] if i < len(normalized_keyword_scores) else 0.0,
+            )
 
         # Combine: union of both result sets
         all_node_ids = set(vector_dict.keys()) | set(keyword_dict.keys())
@@ -612,6 +633,7 @@ ORDER BY score DESC
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _node_to_payload(node: ASTNode) -> dict:
     """Convert an ASTNode to a Qdrant payload dict."""
     return {
@@ -631,6 +653,7 @@ def _node_to_payload(node: ASTNode) -> dict:
 def _payload_to_node(payload: dict) -> ASTNode:
     """Reconstruct a minimal ASTNode from Qdrant payload (for search results)."""
     from ast_rag.models import Language as Lang
+
     return ASTNode(
         id=payload.get("node_id", ""),
         kind=NodeKind(payload.get("kind", "Function")),

--- a/ast_rag/services/embedding_server.py
+++ b/ast_rag/services/embedding_server.py
@@ -76,6 +76,7 @@ async def _startup() -> None:
 # Request / Response models
 # ---------------------------------------------------------------------------
 
+
 class EmbedRequest(BaseModel):
     texts: list[str] = Field(..., min_length=1, description="Texts to embed")
     normalize: bool = Field(True, description="L2-normalize output vectors")
@@ -98,6 +99,7 @@ class HealthResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
+
 
 @app.get("/health", response_model=HealthResponse)
 async def health() -> HealthResponse:
@@ -147,6 +149,7 @@ async def embed(request: EmbedRequest) -> EmbedResponse:
 # CLI entry point
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
     """Run the embedding server from the command line.
 
@@ -156,11 +159,11 @@ def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="AST-RAG embedding HTTP server")
-    parser.add_argument("--model",  default="BAAI/bge-m3",  help="HuggingFace model name")
-    parser.add_argument("--device", default="cuda",          help="Torch device (cuda/cpu)")
-    parser.add_argument("--host",   default="0.0.0.0",       help="Bind host")
-    parser.add_argument("--port",   type=int, default=8765,  help="Port to listen on")
-    parser.add_argument("--workers", type=int, default=1,    help="Number of uvicorn workers")
+    parser.add_argument("--model", default="BAAI/bge-m3", help="HuggingFace model name")
+    parser.add_argument("--device", default="cuda", help="Torch device (cuda/cpu)")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    parser.add_argument("--port", type=int, default=8765, help="Port to listen on")
+    parser.add_argument("--workers", type=int, default=1, help="Number of uvicorn workers")
     args = parser.parse_args()
 
     # Push config into module-level globals before startup

--- a/ast_rag/services/embedding_service.py
+++ b/ast_rag/services/embedding_service.py
@@ -120,7 +120,7 @@ class EmbeddingService:
 
     def index_embeddings(
         self,
-        nodes: list[ASTNode],
+        nodes: "list[ASTNode]",  # noqa: F821
         batch_size: int = 32,
     ) -> int:
         """Index embeddings for a list of AST nodes.

--- a/ast_rag/services/graph_updater_service.py
+++ b/ast_rag/services/graph_updater_service.py
@@ -128,7 +128,7 @@ def _nodes_to_batch_by_label(nodes: list[ASTNode]) -> dict[str, list[dict]]:
     """Group node property dicts by their Neo4j label."""
     by_label: dict[str, list[dict]] = {}
     for node in nodes:
-        label = _KIND_TO_LABEL.get(node.kind.value, "Class")
+        label = KIND_TO_LABEL.get(node.kind.value, "Class")
         by_label.setdefault(label, []).append(node.to_neo4j_props())
     return by_label
 
@@ -140,7 +140,7 @@ def _expired_nodes_by_label(ids: list[str], existing_nodes: list[ASTNode]) -> di
     for nid in ids:
         node = id_to_node.get(nid)
         if node:
-            label = _KIND_TO_LABEL.get(node.kind.value, "Class")
+            label = KIND_TO_LABEL.get(node.kind.value, "Class")
             by_label.setdefault(label, []).append(nid)
     return by_label
 
@@ -768,7 +768,7 @@ def extract_and_store_blocks(
         Tuple of (blocks, edges) where edges are CONTAINS_BLOCK relationships
     """
     from ast_rag.services.parsing.block_extractor import BlockExtractor
-    from ast_rag.models import ASTBlock, ASTEdge, EdgeKind
+    from ast_rag.models import ASTEdge, EdgeKind
 
     # Filter to only function/method nodes
     from ast_rag.models import NodeKind

--- a/ast_rag/services/parsing/__init__.py
+++ b/ast_rag/services/parsing/__init__.py
@@ -11,10 +11,6 @@ from ast_rag.services.parsing.cpp import CPP_QUERIES
 from ast_rag.services.parsing.rust import RUST_QUERIES
 from ast_rag.services.parsing.python import PYTHON_QUERIES
 from ast_rag.services.parsing.typescript import TYPESCRIPT_QUERIES
-from ast_rag.services.parsing.block_extractor import BlockExtractor  # noqa: E402
-from ast_rag.services.parsing.parser_manager import ParserManager  # noqa: E402
-from ast_rag.services.parsing.node_extractor import NodeExtractor  # noqa: E402
-from ast_rag.services.parsing.edge_extractor import EdgeExtractor  # noqa: E402
 
 LANGUAGE_QUERIES: dict[str, dict[str, str]] = {
     "java": JAVA_QUERIES,
@@ -23,6 +19,11 @@ LANGUAGE_QUERIES: dict[str, dict[str, str]] = {
     "python": PYTHON_QUERIES,
     "typescript": TYPESCRIPT_QUERIES,
 }
+
+from ast_rag.services.parsing.block_extractor import BlockExtractor  # noqa: E402
+from ast_rag.services.parsing.parser_manager import ParserManager  # noqa: E402
+from ast_rag.services.parsing.node_extractor import NodeExtractor  # noqa: E402
+from ast_rag.services.parsing.edge_extractor import EdgeExtractor  # noqa: E402
 
 __all__ = [
     "LANGUAGE_QUERIES",

--- a/ast_rag/services/parsing/__init__.py
+++ b/ast_rag/services/parsing/__init__.py
@@ -11,6 +11,10 @@ from ast_rag.services.parsing.cpp import CPP_QUERIES
 from ast_rag.services.parsing.rust import RUST_QUERIES
 from ast_rag.services.parsing.python import PYTHON_QUERIES
 from ast_rag.services.parsing.typescript import TYPESCRIPT_QUERIES
+from ast_rag.services.parsing.block_extractor import BlockExtractor  # noqa: E402
+from ast_rag.services.parsing.parser_manager import ParserManager  # noqa: E402
+from ast_rag.services.parsing.node_extractor import NodeExtractor  # noqa: E402
+from ast_rag.services.parsing.edge_extractor import EdgeExtractor  # noqa: E402
 
 LANGUAGE_QUERIES: dict[str, dict[str, str]] = {
     "java": JAVA_QUERIES,
@@ -19,11 +23,6 @@ LANGUAGE_QUERIES: dict[str, dict[str, str]] = {
     "python": PYTHON_QUERIES,
     "typescript": TYPESCRIPT_QUERIES,
 }
-
-from ast_rag.services.parsing.block_extractor import BlockExtractor
-from ast_rag.services.parsing.parser_manager import ParserManager
-from ast_rag.services.parsing.node_extractor import NodeExtractor
-from ast_rag.services.parsing.edge_extractor import EdgeExtractor
 
 __all__ = [
     "LANGUAGE_QUERIES",

--- a/ast_rag/services/parsing/block_extractor.py
+++ b/ast_rag/services/parsing/block_extractor.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 
 import logging
 from typing import Optional
-from collections import defaultdict
 
-from tree_sitter import Tree, QueryCursor, Node
+from tree_sitter import Tree, Node
 
 from ast_rag.models import ASTBlock, BlockType, Language, ASTNode
 from ast_rag.services.parsing import LANGUAGE_QUERIES
@@ -104,8 +103,6 @@ class BlockExtractor:
             qstr = lang_queries.get(qname)
             if qstr:
                 try:
-                    from tree_sitter import Language, Query
-
                     # We need the language object - extract from context
                     # For now, we'll compile queries on-demand
                     compiled_queries[qname] = qstr
@@ -149,13 +146,7 @@ class BlockExtractor:
                 continue
 
             try:
-                from tree_sitter import Language, Query, Parser
-
                 # Get the language
-                lang_map = {
-                    "python": "python",
-                    "rust": "rust",
-                }
                 # We need to get the actual Language object
                 # This is a bit tricky - we'll use a different approach
                 # Just iterate through the tree manually for now

--- a/ast_rag/services/parsing/edge_extractor.py
+++ b/ast_rag/services/parsing/edge_extractor.py
@@ -615,9 +615,16 @@ class EdgeExtractor:
                     target_id = hashlib.sha256(f"crossfile:{symbol_name}".encode()).hexdigest()[:24]
                     enclosing_method = None
                     for n in nodes:
-                        if n.kind in (NodeKind.METHOD, NodeKind.FUNCTION, NodeKind.CONSTRUCTOR, NodeKind.DESTRUCTOR):
+                        if n.kind in (
+                            NodeKind.METHOD,
+                            NodeKind.FUNCTION,
+                            NodeKind.CONSTRUCTOR,
+                            NodeKind.DESTRUCTOR,
+                        ):
                             if n.start_byte <= node.start_byte and n.end_byte >= node.end_byte:
-                                if enclosing_method is None or (n.end_byte - n.start_byte) < (enclosing_method.end_byte - enclosing_method.start_byte):
+                                if enclosing_method is None or (n.end_byte - n.start_byte) < (
+                                    enclosing_method.end_byte - enclosing_method.start_byte
+                                ):
                                     enclosing_method = n
                     from_id = enclosing_method.id if enclosing_method else file_node_id
                     edges.append(
@@ -752,11 +759,6 @@ def _add_type_relation_edges(
                             valid_from=commit_hash,
                         )
                     )
-
-        if lang == "rust":
-            edges.extend(
-                self._extract_rust_edges(tree, nodes, source, commit_hash, compiled_queries)
-            )
 
         return edges
 

--- a/ast_rag/services/parsing/parser_manager.py
+++ b/ast_rag/services/parsing/parser_manager.py
@@ -204,7 +204,7 @@ class ParserManager:
         source: Optional[bytes] = None,
         commit_hash: str = "INIT",
     ) -> tuple[list[ASTBlock], list[ASTEdge]]:
-        from ast_rag.models import ASTBlock, ASTEdge, EdgeKind, NodeKind
+        from ast_rag.models import ASTEdge, EdgeKind, NodeKind
 
         if lang not in ("python", "rust"):
             return [], []

--- a/ast_rag/services/parsing_service.py
+++ b/ast_rag/services/parsing_service.py
@@ -69,7 +69,7 @@ class ParsingService:
             ValueError: If the language is not supported
         """
         file_path_str = str(file_path)
-        
+
         # Check if file exists
         if not os.path.exists(file_path_str):
             raise FileNotFoundError(f"File not found: {file_path_str}")
@@ -138,7 +138,7 @@ class ParsingService:
             Tuple of (nodes, edges) extracted from all files
         """
         dir_path_str = str(dir_path)
-        
+
         if not os.path.isdir(dir_path_str):
             raise ValueError(f"Directory not found: {dir_path_str}")
 
@@ -156,16 +156,19 @@ class ParsingService:
 
         # Filter by language if specified
         if lang:
-            source_files = [(f, l) for f, l in source_files if l == lang]
+            source_files = [(f, lang_val) for f, lang_val in source_files if lang_val == lang]
 
         # Apply exclude patterns
         if self._exclude_patterns:
             import fnmatch
+
             filtered_files = []
             for fpath, file_lang in source_files:
                 excluded = False
                 for pattern in self._exclude_patterns:
-                    if fnmatch.fnmatch(fpath, pattern) or fnmatch.fnmatch(os.path.basename(fpath), pattern):
+                    if fnmatch.fnmatch(fpath, pattern) or fnmatch.fnmatch(
+                        os.path.basename(fpath), pattern
+                    ):
                         excluded = True
                         break
                 if not excluded:

--- a/ast_rag/services/search_service.py
+++ b/ast_rag/services/search_service.py
@@ -160,7 +160,7 @@ LIMIT 100
         # Parse pattern to extract name and signature parts
         # Simple implementation: treat as name pattern with optional signature
         name_pattern = pattern.split("(")[0].strip() if "(" in pattern else pattern
-        signature_part = pattern[len(name_pattern):].strip() if "(" in pattern else ""
+        signature_part = pattern[len(name_pattern) :].strip() if "(" in pattern else ""
 
         conditions = ["n.valid_to IS NULL", "n.kind IN ['Function', 'Method', 'Constructor']"]
         params: dict[str, str] = {}
@@ -262,34 +262,140 @@ LIMIT $limit
     def _extract_identifiers(self, text: str) -> list[str]:
         """Extract identifiers from text (camelCase, snake_case, etc.)."""
         # Match camelCase, snake_case, and simple identifiers
-        pattern = r'\b[a-zA-Z_][a-zA-Z0-9_]*\b'
+        pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*\b"
         identifiers = re.findall(pattern, text)
 
         # Filter out common words and short identifiers
         common_words = {
-            'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
-            'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
-            'should', 'may', 'might', 'can', 'this', 'that', 'these', 'those',
-            'i', 'you', 'he', 'she', 'it', 'we', 'they', 'what', 'which', 'who',
-            'when', 'where', 'why', 'how', 'all', 'each', 'every', 'both', 'few',
-            'more', 'most', 'other', 'some', 'such', 'no', 'nor', 'not', 'only',
-            'own', 'same', 'so', 'than', 'too', 'very', 'just', 'because', 'but',
-            'and', 'or', 'if', 'while', 'for', 'with', 'about', 'against', 'between',
-            'into', 'through', 'during', 'before', 'after', 'above', 'below', 'to',
-            'from', 'up', 'down', 'in', 'out', 'on', 'off', 'over', 'under', 'again',
-            'further', 'then', 'once', 'here', 'there', 'when', 'where', 'why', 'how',
-            'error', 'exception', 'failed', 'failure', 'success', 'warning', 'info',
-            'debug', 'trace', 'log', 'message', 'code', 'line', 'file', 'function',
-            'method', 'class', 'module', 'package', 'import', 'return', 'value',
+            "the",
+            "a",
+            "an",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "being",
+            "have",
+            "has",
+            "had",
+            "do",
+            "does",
+            "did",
+            "will",
+            "would",
+            "could",
+            "should",
+            "may",
+            "might",
+            "can",
+            "this",
+            "that",
+            "these",
+            "those",
+            "i",
+            "you",
+            "he",
+            "she",
+            "it",
+            "we",
+            "they",
+            "what",
+            "which",
+            "who",
+            "when",
+            "where",
+            "why",
+            "how",
+            "all",
+            "each",
+            "every",
+            "both",
+            "few",
+            "more",
+            "most",
+            "other",
+            "some",
+            "such",
+            "no",
+            "nor",
+            "not",
+            "only",
+            "own",
+            "same",
+            "so",
+            "than",
+            "too",
+            "very",
+            "just",
+            "because",
+            "but",
+            "and",
+            "or",
+            "if",
+            "while",
+            "for",
+            "with",
+            "about",
+            "against",
+            "between",
+            "into",
+            "through",
+            "during",
+            "before",
+            "after",
+            "above",
+            "below",
+            "to",
+            "from",
+            "up",
+            "down",
+            "in",
+            "out",
+            "on",
+            "off",
+            "over",
+            "under",
+            "again",
+            "further",
+            "then",
+            "once",
+            "here",
+            "there",
+            "when",
+            "where",
+            "why",
+            "how",
+            "error",
+            "exception",
+            "failed",
+            "failure",
+            "success",
+            "warning",
+            "info",
+            "debug",
+            "trace",
+            "log",
+            "message",
+            "code",
+            "line",
+            "file",
+            "function",
+            "method",
+            "class",
+            "module",
+            "package",
+            "import",
+            "return",
+            "value",
         }
 
         # Filter and deduplicate
         filtered = []
         seen = set()
         for ident in identifiers:
-            if (len(ident) > 2 and
-                ident.lower() not in common_words and
-                ident not in seen):
+            if len(ident) > 2 and ident.lower() not in common_words and ident not in seen:
                 filtered.append(ident)
                 seen.add(ident)
 
@@ -344,16 +450,18 @@ LIMIT $limit
             with self._driver.session() as session:
                 for record in session.run(cypher, **params):
                     block_data = dict(record["b"])
-                    results.append({
-                        "id": block_data.get("id", ""),
-                        "block_type": block_data.get("block_type", ""),
-                        "lang": block_data.get("lang", ""),
-                        "file_path": block_data.get("file_path", ""),
-                        "start_line": block_data.get("start_line", 0),
-                        "end_line": block_data.get("end_line", 0),
-                        "nesting_depth": block_data.get("nesting_depth", 0),
-                        "parent_function_id": block_data.get("parent_function_id", ""),
-                    })
+                    results.append(
+                        {
+                            "id": block_data.get("id", ""),
+                            "block_type": block_data.get("block_type", ""),
+                            "lang": block_data.get("lang", ""),
+                            "file_path": block_data.get("file_path", ""),
+                            "start_line": block_data.get("start_line", 0),
+                            "end_line": block_data.get("end_line", 0),
+                            "nesting_depth": block_data.get("nesting_depth", 0),
+                            "parent_function_id": block_data.get("parent_function_id", ""),
+                        }
+                    )
         except Exception as exc:
             logger.warning("Block search failed: %s", exc)
 

--- a/ast_rag/services/summarizer_service.py
+++ b/ast_rag/services/summarizer_service.py
@@ -36,8 +36,10 @@ logger = logging.getLogger(__name__)
 # Summary data models
 # ---------------------------------------------------------------------------
 
+
 class ComplexityLevel(str, Enum):
     """Estimated complexity level of a function/class."""
+
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
@@ -62,43 +64,38 @@ class NodeSummary(BaseModel):
         generated_at: ISO timestamp when summary was generated
         model_used: Name of the LLM model used for generation
     """
+
     node_id: str
     summary: str = Field(..., description="Natural language summary of the code")
     inputs: list[dict[str, str]] = Field(
-        default_factory=list,
-        description="Input parameters: [{name, type, description}, ...]"
+        default_factory=list, description="Input parameters: [{name, type, description}, ...]"
     )
     outputs: list[dict[str, str]] = Field(
-        default_factory=list,
-        description="Return values: [{name, type, description}, ...]"
+        default_factory=list, description="Return values: [{name, type, description}, ...]"
     )
     side_effects: list[str] = Field(
         default_factory=list,
-        description="Side effects: IO operations, state mutations, exceptions thrown"
+        description="Side effects: IO operations, state mutations, exceptions thrown",
     )
     calls: list[str] = Field(
-        default_factory=list,
-        description="Functions/methods called by this node (qualified names)"
+        default_factory=list, description="Functions/methods called by this node (qualified names)"
     )
     called_by: list[str] = Field(
-        default_factory=list,
-        description="Functions/methods that call this node (qualified names)"
+        default_factory=list, description="Functions/methods that call this node (qualified names)"
     )
     complexity: ComplexityLevel = Field(
-        default=ComplexityLevel.MEDIUM,
-        description="Estimated complexity level"
+        default=ComplexityLevel.MEDIUM, description="Estimated complexity level"
     )
     tags: list[str] = Field(
         default_factory=list,
-        description="Relevant tags: async, pure, deprecated, thread-safe, etc."
+        description="Relevant tags: async, pure, deprecated, thread-safe, etc.",
     )
     generated_at: str = Field(
         default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        description="ISO timestamp of summary generation"
+        description="ISO timestamp of summary generation",
     )
     model_used: Optional[str] = Field(
-        default=None,
-        description="LLM model name used for generation"
+        default=None, description="LLM model name used for generation"
     )
 
     def to_dict(self) -> dict[str, Any]:
@@ -164,6 +161,7 @@ class NodeSummary(BaseModel):
 
 class SummaryCacheEntry(BaseModel):
     """Cache entry for a generated summary."""
+
     node_id: str
     code_hash: str  # Hash of the code to detect changes
     summary: NodeSummary
@@ -269,6 +267,7 @@ Example response structure:
 # Summarizer Service
 # ---------------------------------------------------------------------------
 
+
 class SummarizerService:
     """Service for generating code summaries using local OpenAI-compatible LLM.
 
@@ -339,10 +338,7 @@ class SummarizerService:
         """Load summary cache from disk."""
         try:
             data = json.loads(self._cache_path.read_text(encoding="utf-8"))
-            self._cache = {
-                k: SummaryCacheEntry.model_validate(v)
-                for k, v in data.items()
-            }
+            self._cache = {k: SummaryCacheEntry.model_validate(v) for k, v in data.items()}
             logger.info("Loaded %d summary cache entries", len(self._cache))
         except Exception as exc:
             logger.warning("Failed to load summary cache: %s", exc)
@@ -353,14 +349,8 @@ class SummarizerService:
         if not self._cache_enabled:
             return
         try:
-            data = {
-                k: v.model_dump()
-                for k, v in self._cache.items()
-            }
-            self._cache_path.write_text(
-                json.dumps(data, indent=2),
-                encoding="utf-8"
-            )
+            data = {k: v.model_dump() for k, v in self._cache.items()}
+            self._cache_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
             logger.debug("Saved %d summary cache entries", len(self._cache))
         except Exception as exc:
             logger.warning("Failed to save summary cache: %s", exc)
@@ -417,12 +407,9 @@ class SummarizerService:
             "messages": [
                 {
                     "role": "system",
-                    "content": "You are an expert code analyst specializing in understanding and summarizing code across multiple programming languages."
+                    "content": "You are an expert code analyst specializing in understanding and summarizing code across multiple programming languages.",
                 },
-                {
-                    "role": "user",
-                    "content": prompt
-                }
+                {"role": "user", "content": prompt},
             ],
             "temperature": 0.1,  # Low temperature for consistent structured output
             "stream": False,
@@ -454,15 +441,19 @@ class SummarizerService:
         """Build caller and callee context strings."""
         # Get callers
         callers = api.find_callers(node.id, max_depth=1)
-        callers_context = "\n".join(
-            f"- {c.qualified_name}" for c in callers[:max_callers]
-        ) if callers else "- (none)"
+        callers_context = (
+            "\n".join(f"- {c.qualified_name}" for c in callers[:max_callers])
+            if callers
+            else "- (none)"
+        )
 
         # Get callees
         callees = api.find_callees(node.id, max_depth=1)
-        calls_context = "\n".join(
-            f"- {c.qualified_name}" for c in callees[:max_callees]
-        ) if callees else "- (none)"
+        calls_context = (
+            "\n".join(f"- {c.qualified_name}" for c in callees[:max_callees])
+            if callees
+            else "- (none)"
+        )
 
         return calls_context, callers_context
 
@@ -487,7 +478,8 @@ class SummarizerService:
             logger.warning("Failed to parse LLM JSON: %s", exc)
             # Try to find JSON in the response
             import re
-            json_match = re.search(r'\{.*\}', text, re.DOTALL)
+
+            json_match = re.search(r"\{.*\}", text, re.DOTALL)
             if json_match:
                 try:
                     return json.loads(json_match.group())
@@ -529,10 +521,14 @@ class SummarizerService:
 
         # Check if node kind is summarizable
         summarizable_kinds = {
-            NodeKind.FUNCTION, NodeKind.METHOD,
-            NodeKind.CONSTRUCTOR, NodeKind.DESTRUCTOR,
-            NodeKind.CLASS, NodeKind.INTERFACE,
-            NodeKind.STRUCT, NodeKind.TRAIT,
+            NodeKind.FUNCTION,
+            NodeKind.METHOD,
+            NodeKind.CONSTRUCTOR,
+            NodeKind.DESTRUCTOR,
+            NodeKind.CLASS,
+            NodeKind.INTERFACE,
+            NodeKind.STRUCT,
+            NodeKind.TRAIT,
         }
         if node.kind not in summarizable_kinds:
             raise ValueError(
@@ -558,9 +554,7 @@ class SummarizerService:
                 return cached
 
         # Build context
-        calls_context, callers_context = self._build_context(
-            node, api, max_callers, max_callees
-        )
+        calls_context, callers_context = self._build_context(node, api, max_callers, max_callees)
 
         # Build prompt
         prompt = SUMMARY_PROMPT_TEMPLATE.format(
@@ -575,11 +569,12 @@ class SummarizerService:
             "Generating summary for %s (%s) - code lines: %d",
             node.qualified_name,
             node.kind.value,
-            node.end_line - node.start_line + 1
+            node.end_line - node.start_line + 1,
         )
 
         # Call LLM (synchronous wrapper for async)
         import asyncio
+
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
@@ -599,8 +594,16 @@ class SummarizerService:
                 "inputs": [],
                 "outputs": [],
                 "side_effects": ["Unknown"],
-                "calls": [c.split("- ")[1] for c in calls_context.split("\n") if c.startswith("- ") and c != "- (none)"],
-                "called_by": [c.split("- ")[1] for c in callers_context.split("\n") if c.startswith("- ") and c != "- (none)"],
+                "calls": [
+                    c.split("- ")[1]
+                    for c in calls_context.split("\n")
+                    if c.startswith("- ") and c != "- (none)"
+                ],
+                "called_by": [
+                    c.split("- ")[1]
+                    for c in callers_context.split("\n")
+                    if c.startswith("- ") and c != "- (none)"
+                ],
                 "complexity": "medium",
                 "tags": [],
             }
@@ -614,9 +617,7 @@ class SummarizerService:
             side_effects=parsed.get("side_effects", []),
             calls=parsed.get("calls", []),
             called_by=parsed.get("called_by", []),
-            complexity=ComplexityLevel(
-                parsed.get("complexity", "medium")
-            ),
+            complexity=ComplexityLevel(parsed.get("complexity", "medium")),
             tags=parsed.get("tags", []),
             model_used=self._model,
         )

--- a/ast_rag/stack_trace/models.py
+++ b/ast_rag/stack_trace/models.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 
 class Language(str, Enum):
     """Supported languages for stack trace parsing."""
+
     PYTHON = "python"
     CPP = "cpp"
     JAVA = "java"
@@ -28,6 +29,7 @@ class Language(str, Enum):
 
 class FrameType(str, Enum):
     """Type of stack frame."""
+
     FUNCTION_CALL = "function_call"
     METHOD_CALL = "method_call"
     CONSTRUCTOR = "constructor"
@@ -38,7 +40,7 @@ class FrameType(str, Enum):
 
 class StackFrame(BaseModel):
     """Represents a single frame in a stack trace.
-    
+
     Attributes:
         frame_index: Position in the call stack (0 = topmost/innermost)
         function_name: Name of the function/method
@@ -56,6 +58,7 @@ class StackFrame(BaseModel):
         code_snippet: Source code snippet (populated after AST mapping)
         ast_node_id: AST node ID (populated after AST mapping)
     """
+
     frame_index: int
     function_name: str
     class_name: Optional[str] = None
@@ -72,7 +75,7 @@ class StackFrame(BaseModel):
     code_snippet: Optional[str] = None
     ast_node_id: Optional[str] = None
     ast_node_qualified_name: Optional[str] = None
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         return {
@@ -97,7 +100,7 @@ class StackFrame(BaseModel):
 
 class RootCause(BaseModel):
     """Analysis of the root cause of the error.
-    
+
     Attributes:
         error_type: Type/class of the error (e.g., NullPointerException)
         error_message: The error message text
@@ -108,6 +111,7 @@ class RootCause(BaseModel):
         confidence: Confidence score (0.0-1.0) in the analysis
         related_frames: Indices of frames related to the root cause
     """
+
     error_type: str
     error_message: str
     likely_cause: Optional[str] = None
@@ -116,7 +120,7 @@ class RootCause(BaseModel):
     suggested_fix: Optional[str] = None
     confidence: float = 0.0
     related_frames: list[int] = Field(default_factory=list)
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         return {
@@ -133,7 +137,7 @@ class RootCause(BaseModel):
 
 class SimilarIssue(BaseModel):
     """Represents a similar issue found in the codebase or knowledge base.
-    
+
     Attributes:
         issue_id: Unique identifier for the issue
         title: Issue title/description
@@ -143,6 +147,7 @@ class SimilarIssue(BaseModel):
         source: Source of the issue (internal, stackoverflow, github, etc.)
         url: Link to the issue (if available)
     """
+
     issue_id: str
     title: str
     location: Optional[str] = None
@@ -150,7 +155,7 @@ class SimilarIssue(BaseModel):
     resolution: Optional[str] = None
     source: str = "internal"
     url: Optional[str] = None
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         return {
@@ -166,9 +171,9 @@ class SimilarIssue(BaseModel):
 
 class StackTraceReport(BaseModel):
     """Complete analysis report for a stack trace.
-    
+
     This is the main output model for StackTraceService.analyze().
-    
+
     Attributes:
         error_type: Primary error type (e.g., NullPointerException)
         message: Full error message
@@ -181,6 +186,7 @@ class StackTraceReport(BaseModel):
         mapped_frames: Number of frames successfully mapped to AST
         analysis_metadata: Additional metadata about the analysis
     """
+
     error_type: str
     message: str
     language: Language = Language.UNKNOWN
@@ -191,7 +197,7 @@ class StackTraceReport(BaseModel):
     total_frames: int = 0
     mapped_frames: int = 0
     analysis_metadata: dict[str, Any] = Field(default_factory=dict)
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         return {
@@ -206,21 +212,24 @@ class StackTraceReport(BaseModel):
             "mapped_frames": self.mapped_frames,
             "analysis_metadata": self.analysis_metadata,
         }
-    
+
     def to_json(self, indent: int = 2) -> str:
         """Convert to JSON string."""
         import json
+
         return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
-    
+
     def to_markdown(self) -> str:
         """Render as Markdown for chat display."""
         lines = []
-        lines.append(f"# Stack Trace Analysis Report\n")
+        lines.append("# Stack Trace Analysis Report\n")
         lines.append(f"## Error: `{self.error_type}`\n")
         lines.append(f"**Message:** {self.message}\n")
         lines.append(f"**Language:** {self.language.value}\n")
-        lines.append(f"**Total Frames:** {self.total_frames} ({self.mapped_frames} mapped to AST)\n")
-        
+        lines.append(
+            f"**Total Frames:** {self.total_frames} ({self.mapped_frames} mapped to AST)\n"
+        )
+
         if self.root_cause:
             lines.append("\n## Root Cause Analysis\n")
             lines.append(f"- **Type:** {self.root_cause.error_type}")
@@ -231,7 +240,7 @@ class StackTraceReport(BaseModel):
                 lines.append(f"- **Likely Cause:** {self.root_cause.likely_cause}")
             if self.root_cause.suggested_fix:
                 lines.append(f"- **Suggested Fix:** {self.root_cause.suggested_fix}")
-        
+
         if self.call_chain:
             lines.append("\n## Call Chain\n")
             for frame in self.call_chain[:10]:  # Show first 10
@@ -241,16 +250,16 @@ class StackTraceReport(BaseModel):
                 lines.append(f"{frame.frame_index}. `{frame.function_name}()`{loc}")
             if len(self.call_chain) > 10:
                 lines.append(f"... and {len(self.call_chain) - 10} more frames")
-        
+
         if self.similar_issues:
             lines.append("\n## Similar Issues\n")
             for issue in self.similar_issues[:5]:  # Show first 5
                 lines.append(f"- [{issue.similarity_score:.0%}] {issue.title}")
                 if issue.resolution:
                     lines.append(f"  - Resolution: {issue.resolution}")
-        
+
         if self.summary:
-            lines.append(f"\n## Summary\n")
+            lines.append("\n## Summary\n")
             lines.append(self.summary)
-        
+
         return "\n".join(lines)

--- a/ast_rag/stack_trace/parsers.py
+++ b/ast_rag/stack_trace/parsers.py
@@ -14,45 +14,44 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from .models import StackFrame, FrameType, Language
 
 
 class StackTraceParser(ABC):
     """Abstract base class for stack trace parsers."""
-    
+
     @abstractmethod
     def parse(self, stacktrace: str) -> list[StackFrame]:
         """Parse a stack trace string into a list of StackFrame objects.
-        
+
         Args:
             stacktrace: Raw stack trace text
-            
+
         Returns:
             List of StackFrame objects in order (top to bottom)
         """
         pass
-    
+
     @abstractmethod
     def detect_language(self, stacktrace: str) -> Language:
         """Detect the language of a stack trace.
-        
+
         Args:
             stacktrace: Raw stack trace text
-            
+
         Returns:
             Detected Language enum value
         """
         pass
-    
+
     @abstractmethod
     def extract_error_info(self, stacktrace: str) -> tuple[str, str]:
         """Extract error type and message from stack trace.
-        
+
         Args:
             stacktrace: Raw stack trace text
-            
+
         Returns:
             Tuple of (error_type, error_message)
         """
@@ -61,7 +60,7 @@ class StackTraceParser(ABC):
 
 class PythonParser(StackTraceParser):
     """Parser for Python stack traces.
-    
+
     Format examples:
         Traceback (most recent call last):
           File "main.py", line 42, in <module>
@@ -71,283 +70,295 @@ class PythonParser(StackTraceParser):
           File "transform.py", line 8, in transform
             raise ValueError("Invalid input")
         ValueError: Invalid input
-    
+
     Also handles asyncio traces:
         Task exception was never retrieved
         future: <Task finished name='Task-1' coro=<async_func() done, defined at test.py:10>>
         Traceback (most recent call last):
           File "test.py", line 12, in async_func
     """
-    
+
     # Pattern for standard Python stack frames
     FRAME_PATTERN = re.compile(
         r'^\s+File\s+"(?P<file>[^"]+)"'  # File "path.py"
-        r',\s+line\s+(?P<line>\d+)'       # , line 42
-        r'(?:,\s+in\s+(?P<func>[^\s]+))?'  # , in function_name
-        r'(?:\s*->\s*(?P<async_marker>async))?',  # -> async (for async frames)
-        re.MULTILINE
+        r",\s+line\s+(?P<line>\d+)"  # , line 42
+        r"(?:,\s+in\s+(?P<func>[^\s]+))?"  # , in function_name
+        r"(?:\s*->\s*(?P<async_marker>async))?",  # -> async (for async frames)
+        re.MULTILINE,
     )
-    
+
     # Pattern for error type and message (last line)
     ERROR_PATTERN = re.compile(
-        r'^(?P<error>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)'  # Error type
-        r'(?::\s*(?P<message>.*))?$',  # : message
-        re.MULTILINE
+        r"^(?P<error>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)"  # Error type
+        r"(?::\s*(?P<message>.*))?$",  # : message
+        re.MULTILINE,
     )
-    
+
     # Pattern for asyncio task traces
     ASYNC_PATTERN = re.compile(
-        r'coro=<(?P<func>[^\s()]+)\(\)\s+done,\s+defined\s+at\s+(?P<file>[^:]+):(?P<line>\d+)'
+        r"coro=<(?P<func>[^\s()]+)\(\)\s+done,\s+defined\s+at\s+(?P<file>[^:]+):(?P<line>\d+)"
     )
-    
+
     def detect_language(self, stacktrace: str) -> Language:
         """Detect Python stack trace by characteristic patterns."""
         indicators = [
-            'Traceback (most recent call last)',
+            "Traceback (most recent call last)",
             'File "',
-            ', line ',
-            'in <module>',
-            'Task exception was never retrieved',
+            ", line ",
+            "in <module>",
+            "Task exception was never retrieved",
         ]
         return Language.PYTHON if any(ind in stacktrace for ind in indicators) else Language.UNKNOWN
-    
+
     def extract_error_info(self, stacktrace: str) -> tuple[str, str]:
         """Extract error type and message from Python stack trace."""
-        lines = stacktrace.strip().split('\n')
-        
+        lines = stacktrace.strip().split("\n")
+
         # Look for the last non-empty line that matches error pattern
         for line in reversed(lines):
             line = line.strip()
             if not line:
                 continue
-            
+
             # Skip common non-error lines
-            if line.startswith('File "') or line.startswith('Traceback') or line.startswith('Task'):
+            if line.startswith('File "') or line.startswith("Traceback") or line.startswith("Task"):
                 continue
-            
+
             match = self.ERROR_PATTERN.match(line)
             if match:
-                error_type = match.group('error')
-                message = match.group('message') or ''
+                error_type = match.group("error")
+                message = match.group("message") or ""
                 return error_type, message
-        
+
         # Fallback: use last line as error message
         for line in reversed(lines):
             line = line.strip()
-            if line and not line.startswith('File "') and not line.startswith('Traceback'):
-                if ':' in line:
-                    parts = line.split(':', 1)
+            if line and not line.startswith('File "') and not line.startswith("Traceback"):
+                if ":" in line:
+                    parts = line.split(":", 1)
                     return parts[0].strip(), parts[1].strip()
-                return 'Error', line
-        
-        return 'UnknownError', ''
-    
+                return "Error", line
+
+        return "UnknownError", ""
+
     def parse(self, stacktrace: str) -> list[StackFrame]:
         """Parse Python stack trace into frames."""
         frames = []
-        lines = stacktrace.split('\n')
-        
+        lines = stacktrace.split("\n")
+
         frame_index = 0
         i = 0
         while i < len(lines):
             line = lines[i]
-            
+
             # Try to match standard frame pattern
             match = self.FRAME_PATTERN.match(line)
             if match:
-                file_path = match.group('file')
-                line_number = int(match.group('line'))
-                func_name = match.group('func') or '<unknown>'
-                is_async = bool(match.group('async_marker'))
-                
+                file_path = match.group("file")
+                line_number = int(match.group("line"))
+                func_name = match.group("func") or "<unknown>"
+                is_async = bool(match.group("async_marker"))
+
                 # Determine frame type
                 frame_type = FrameType.FUNCTION_CALL
                 class_name = None
                 module = None
-                
-                if func_name == '<module>':
-                    func_name = '<module>'
+
+                if func_name == "<module>":
+                    func_name = "<module>"
                     frame_type = FrameType.FUNCTION_CALL
-                elif func_name.startswith('<'):
-                    frame_type = FrameType.LAMBDA if 'lambda' in func_name else FrameType.FUNCTION_CALL
-                elif '.' in func_name:
+                elif func_name.startswith("<"):
+                    frame_type = (
+                        FrameType.LAMBDA if "lambda" in func_name else FrameType.FUNCTION_CALL
+                    )
+                elif "." in func_name:
                     # Might be a method call
-                    parts = func_name.rsplit('.', 1)
+                    parts = func_name.rsplit(".", 1)
                     if len(parts) == 2:
                         class_name = parts[0]
                         func_name = parts[1]
                         frame_type = FrameType.METHOD_CALL
-                
+
                 # Extract module from file path
                 if file_path:
-                    module = file_path.replace('/', '.').replace('\\', '.').replace('.py', '')
-                
-                frames.append(StackFrame(
-                    frame_index=frame_index,
-                    function_name=func_name,
-                    class_name=class_name,
-                    file_path=file_path,
-                    line_number=line_number,
-                    language=Language.PYTHON,
-                    frame_type=frame_type,
-                    raw_line=line.strip(),
-                    module=module,
-                    is_async=is_async,
-                ))
+                    module = file_path.replace("/", ".").replace("\\", ".").replace(".py", "")
+
+                frames.append(
+                    StackFrame(
+                        frame_index=frame_index,
+                        function_name=func_name,
+                        class_name=class_name,
+                        file_path=file_path,
+                        line_number=line_number,
+                        language=Language.PYTHON,
+                        frame_type=frame_type,
+                        raw_line=line.strip(),
+                        module=module,
+                        is_async=is_async,
+                    )
+                )
                 frame_index += 1
                 i += 1
                 continue
-            
+
             # Try async pattern
             async_match = self.ASYNC_PATTERN.search(line)
             if async_match:
-                frames.append(StackFrame(
-                    frame_index=frame_index,
-                    function_name=async_match.group('func'),
-                    file_path=async_match.group('file'),
-                    line_number=int(async_match.group('line')),
-                    language=Language.PYTHON,
-                    frame_type=FrameType.ASYNC_CALLBACK,
-                    raw_line=line.strip(),
-                    is_async=True,
-                ))
+                frames.append(
+                    StackFrame(
+                        frame_index=frame_index,
+                        function_name=async_match.group("func"),
+                        file_path=async_match.group("file"),
+                        line_number=int(async_match.group("line")),
+                        language=Language.PYTHON,
+                        frame_type=FrameType.ASYNC_CALLBACK,
+                        raw_line=line.strip(),
+                        is_async=True,
+                    )
+                )
                 frame_index += 1
-            
+
             i += 1
-        
+
         return frames
 
 
 class CppParser(StackTraceParser):
     """Parser for C++ stack traces.
-    
+
     Format examples (GDB/LLDB style):
         #0  0x00007fff5fbff6c0 in MyClass::myMethod(int) at file.cpp:42
         #1  0x00007fff5fbff700 in process() at main.cpp:15
         #2  0x00007fff5fbff740 in main at main.cpp:8
-    
+
     Also handles:
         #0 0x4005f4 in foo() /path/to/file.cpp:10
         #1 0x400623 in bar() /path/to/file.cpp:20
     """
-    
+
     # Pattern for GDB/LLDB style frames - improved to handle function signatures
     # Matches: #0  0x... in func() at file.cpp:42
     FRAME_PATTERN = re.compile(
-        r'^\s*#(?P<frame_num>\d+)'                    # #0
-        r'\s+(?:0x[0-9a-fA-F]+)?'                      # Optional address
-        r'\s+in\s+(?P<func>[^\s]+)'                    # in function_name
-        r'\s+at\s+'                                    # at
-        r'(?P<file>(?:[A-Za-z]:)?[^:\n]+?'             # file path (handle Windows drive letters)
-        r'\.(?:cpp|cxx|cc|c|hpp|hxx|hh|h|cpp|ipp))'    # extension
-        r'(?::(?P<line>\d+))?',                        # :line (optional)
-        re.MULTILINE
+        r"^\s*#(?P<frame_num>\d+)"  # #0
+        r"\s+(?:0x[0-9a-fA-F]+)?"  # Optional address
+        r"\s+in\s+(?P<func>[^\s]+)"  # in function_name
+        r"\s+at\s+"  # at
+        r"(?P<file>(?:[A-Za-z]:)?[^:\n]+?"  # file path (handle Windows drive letters)
+        r"\.(?:cpp|cxx|cc|c|hpp|hxx|hh|h|cpp|ipp))"  # extension
+        r"(?::(?P<line>\d+))?",  # :line (optional)
+        re.MULTILINE,
     )
-    
+
     # Pattern for error info (often from exception)
     ERROR_PATTERN = re.compile(
-        r'(?:terminate|exception|error)[:\s]+(?:what\(\):\s*)?(?P<message>.+?)(?:\n|$)',
-        re.IGNORECASE
+        r"(?:terminate|exception|error)[:\s]+(?:what\(\):\s*)?(?P<message>.+?)(?:\n|$)",
+        re.IGNORECASE,
     )
-    
+
     def detect_language(self, stacktrace: str) -> Language:
         """Detect C++ stack trace by characteristic patterns."""
         indicators = [
-            re.compile(r'#\d+\s+0x[0-9a-fA-F]+\s+in\s+'),
-            re.compile(r'in\s+[A-Za-z_][A-Za-z0-9_:]*\(\)'),
-            re.compile(r'\.cpp:\d+'),
-            re.compile(r'terminate\s+called'),
-            re.compile(r'std::'),
+            re.compile(r"#\d+\s+0x[0-9a-fA-F]+\s+in\s+"),
+            re.compile(r"in\s+[A-Za-z_][A-Za-z0-9_:]*\(\)"),
+            re.compile(r"\.cpp:\d+"),
+            re.compile(r"terminate\s+called"),
+            re.compile(r"std::"),
         ]
         return Language.CPP if any(p.search(stacktrace) for p in indicators) else Language.UNKNOWN
-    
+
     def extract_error_info(self, stacktrace: str) -> tuple[str, str]:
         """Extract error type and message from C++ stack trace."""
         # Look for exception info
         match = self.ERROR_PATTERN.search(stacktrace)
         if match:
-            message = match.group('message').strip()
+            message = match.group("message").strip()
             # Try to extract exception type
-            if 'std::' in message:
-                type_match = re.search(r'std::([A-Za-z]+)', message)
+            if "std::" in message:
+                type_match = re.search(r"std::([A-Za-z]+)", message)
                 if type_match:
-                    return f'std::{type_match.group(1)}', message
-            return 'std::exception', message
-        
+                    return f"std::{type_match.group(1)}", message
+            return "std::exception", message
+
         # Look for terminate messages
-        term_match = re.search(r'terminate\s+called\s+(?:after\s+throwing\s+)?(?:an\s+instance of\s+)?[\'"]?([^\'"\n]+)[\'"]?', stacktrace, re.IGNORECASE)
+        term_match = re.search(
+            r'terminate\s+called\s+(?:after\s+throwing\s+)?(?:an\s+instance of\s+)?[\'"]?([^\'"\n]+)[\'"]?',
+            stacktrace,
+            re.IGNORECASE,
+        )
         if term_match:
             error_text = term_match.group(1).strip()
-            if 'std::' in error_text:
-                type_match = re.search(r'std::([A-Za-z]+)', error_text)
+            if "std::" in error_text:
+                type_match = re.search(r"std::([A-Za-z]+)", error_text)
                 if type_match:
-                    return f'std::{type_match.group(1)}', error_text
-            return 'std::exception', error_text
-        
-        return 'UnknownError', ''
-    
+                    return f"std::{type_match.group(1)}", error_text
+            return "std::exception", error_text
+
+        return "UnknownError", ""
+
     def parse(self, stacktrace: str) -> list[StackFrame]:
         """Parse C++ stack trace into frames."""
         frames = []
-        
+
         for match in self.FRAME_PATTERN.finditer(stacktrace):
-            frame_num = int(match.group('frame_num'))
-            func_name = match.group('func')
-            file_path = match.group('file')
-            line_number = int(match.group('line')) if match.group('line') else None
-            
+            frame_num = int(match.group("frame_num"))
+            func_name = match.group("func")
+            file_path = match.group("file")
+            line_number = int(match.group("line")) if match.group("line") else None
+
             # Clean function name - remove parameters like (int, char*)
             # e.g., "myMethod(int)" -> "myMethod"
             # e.g., "std::vector<int>::at(unsigned long)" -> "at"
             clean_func = func_name
-            paren_idx = func_name.find('(')
+            paren_idx = func_name.find("(")
             if paren_idx != -1:
                 clean_func = func_name[:paren_idx]
-            
+
             # Parse function name for class::method pattern
             class_name = None
             frame_type = FrameType.FUNCTION_CALL
-            
-            if '::' in clean_func:
-                parts = clean_func.rsplit('::', 1)
+
+            if "::" in clean_func:
+                parts = clean_func.rsplit("::", 1)
                 if len(parts) == 2:
                     class_name = parts[0]
                     func_name = parts[1]
-                    if func_name == (class_name.split('::')[-1]):
+                    if func_name == (class_name.split("::")[-1]):
                         frame_type = FrameType.CONSTRUCTOR
-                    elif func_name.startswith('~'):
+                    elif func_name.startswith("~"):
                         frame_type = FrameType.DESTRUCTOR
                         func_name = func_name[1:]
                     else:
                         frame_type = FrameType.METHOD_CALL
             else:
                 func_name = clean_func
-            
+
             # Extract module from file path
             module = None
             if file_path:
-                module = file_path.replace('/', '.').replace('\\', '.')
-                if module.endswith('.cpp'):
+                module = file_path.replace("/", ".").replace("\\", ".")
+                if module.endswith(".cpp"):
                     module = module[:-4]
-            
-            frames.append(StackFrame(
-                frame_index=frame_num,
-                function_name=func_name,
-                class_name=class_name,
-                file_path=file_path,
-                line_number=line_number,
-                language=Language.CPP,
-                frame_type=frame_type,
-                raw_line=match.group(0).strip(),
-                module=module,
-            ))
-        
+
+            frames.append(
+                StackFrame(
+                    frame_index=frame_num,
+                    function_name=func_name,
+                    class_name=class_name,
+                    file_path=file_path,
+                    line_number=line_number,
+                    language=Language.CPP,
+                    frame_type=frame_type,
+                    raw_line=match.group(0).strip(),
+                    module=module,
+                )
+            )
+
         return frames
 
 
 class JavaParser(StackTraceParser):
     """Parser for Java stack traces.
-    
+
     Format examples:
         java.lang.NullPointerException: Cannot invoke method on null object
             at com.example.MyClass.myMethod(MyClass.java:42)
@@ -356,134 +367,136 @@ class JavaParser(StackTraceParser):
         Caused by: java.lang.IllegalArgumentException: Invalid argument
             at com.example.Validator.validate(Validator.java:25)
             ... 5 more
-    
+
     Also handles:
         - "Caused by:" chains
         - "... N more" suppressed frames
         - Native methods: at java.lang.Object.wait(Native Method)
     """
-    
+
     # Pattern for stack frames
     FRAME_PATTERN = re.compile(
-        r'^\s+at\s+'  # Leading whitespace + "at "
-        r'(?P<func>[^\(]+)'  # function name
-        r'\((?P<location>[^\)]+)\)',  # (File.java:42)
-        re.MULTILINE
+        r"^\s+at\s+"  # Leading whitespace + "at "
+        r"(?P<func>[^\(]+)"  # function name
+        r"\((?P<location>[^\)]+)\)",  # (File.java:42)
+        re.MULTILINE,
     )
-    
+
     # Pattern for exception type and message (first line)
     ERROR_PATTERN = re.compile(
-        r'^(?P<error>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+)'  # Full class name
-        r'(?:\s*:\s*(?P<message>.*))?$',  # : message
-        re.MULTILINE
+        r"^(?P<error>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+)"  # Full class name
+        r"(?:\s*:\s*(?P<message>.*))?$",  # : message
+        re.MULTILINE,
     )
-    
+
     # Pattern for "Caused by:" lines
     CAUSED_BY_PATTERN = re.compile(
-        r'^Caused by:\s+(?P<error>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+)'
-        r'(?:\s*:\s*(?P<message>.*))?$',
-        re.MULTILINE
+        r"^Caused by:\s+(?P<error>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+)"
+        r"(?:\s*:\s*(?P<message>.*))?$",
+        re.MULTILINE,
     )
-    
+
     def detect_language(self, stacktrace: str) -> Language:
         """Detect Java stack trace by characteristic patterns."""
         indicators = [
-            re.compile(r'^\s+at\s+[a-z]+\.[a-z]+'),
-            re.compile(r'\.java:\d+\)'),
-            re.compile(r'Caused by:'),
-            re.compile(r'\.\.\.\s+\d+\s+more'),
-            re.compile(r'java\.lang\.'),
+            re.compile(r"^\s+at\s+[a-z]+\.[a-z]+"),
+            re.compile(r"\.java:\d+\)"),
+            re.compile(r"Caused by:"),
+            re.compile(r"\.\.\.\s+\d+\s+more"),
+            re.compile(r"java\.lang\."),
         ]
         return Language.JAVA if any(p.search(stacktrace) for p in indicators) else Language.UNKNOWN
-    
+
     def extract_error_info(self, stacktrace: str) -> tuple[str, str]:
         """Extract error type and message from Java stack trace."""
-        lines = stacktrace.strip().split('\n')
-        
+        lines = stacktrace.strip().split("\n")
+
         # First line usually has the error
         if lines:
             first_line = lines[0].strip()
             match = self.ERROR_PATTERN.match(first_line)
             if match:
-                return match.group('error'), match.group('message') or ''
-        
+                return match.group("error"), match.group("message") or ""
+
         # Look for "Caused by:" which might have the root cause
         for line in lines:
             match = self.CAUSED_BY_PATTERN.match(line.strip())
             if match:
-                return match.group('error'), match.group('message') or ''
-        
-        return 'Exception', ''
-    
+                return match.group("error"), match.group("message") or ""
+
+        return "Exception", ""
+
     def parse(self, stacktrace: str) -> list[StackFrame]:
         """Parse Java stack trace into frames."""
         frames = []
         frame_index = 0
-        
+
         for match in self.FRAME_PATTERN.finditer(stacktrace):
-            func_full = match.group('func')
-            location = match.group('location')
-            
+            func_full = match.group("func")
+            location = match.group("location")
+
             # Parse function name: package.Class.method
             class_name = None
             func_name = func_full
             module = None
-            
-            if '.' in func_full:
-                parts = func_full.rsplit('.', 1)
+
+            if "." in func_full:
+                parts = func_full.rsplit(".", 1)
                 if len(parts) == 2:
                     module_class = parts[0]
                     func_name = parts[1]
-                    
+
                     # Split module and class
-                    if '.' in module_class:
-                        module_parts = module_class.rsplit('.', 1)
+                    if "." in module_class:
+                        module_parts = module_class.rsplit(".", 1)
                         module = module_parts[0]
                         class_name = module_parts[1]
                     else:
                         class_name = module_class
                         module = module_class
-            
+
             # Parse location: File.java:42 or Native Method
             file_path = None
             line_number = None
             is_native = False
-            
-            if location == 'Native Method':
+
+            if location == "Native Method":
                 is_native = True
-            elif ':' in location:
-                loc_parts = location.rsplit(':', 1)
+            elif ":" in location:
+                loc_parts = location.rsplit(":", 1)
                 file_path = loc_parts[0]
                 if len(loc_parts) > 1 and loc_parts[1].isdigit():
                     line_number = int(loc_parts[1])
-            
+
             # Determine frame type
             frame_type = FrameType.FUNCTION_CALL
             if class_name:
                 frame_type = FrameType.METHOD_CALL
-                if func_name == class_name or func_name == '__init__':
+                if func_name == class_name or func_name == "__init__":
                     frame_type = FrameType.CONSTRUCTOR
-            
-            frames.append(StackFrame(
-                frame_index=frame_index,
-                function_name=func_name,
-                class_name=class_name,
-                file_path=file_path,
-                line_number=line_number,
-                language=Language.JAVA,
-                frame_type=frame_type,
-                raw_line=match.group(0).strip(),
-                module=module,
-                is_native=is_native,
-            ))
+
+            frames.append(
+                StackFrame(
+                    frame_index=frame_index,
+                    function_name=func_name,
+                    class_name=class_name,
+                    file_path=file_path,
+                    line_number=line_number,
+                    language=Language.JAVA,
+                    frame_type=frame_type,
+                    raw_line=match.group(0).strip(),
+                    module=module,
+                    is_native=is_native,
+                )
+            )
             frame_index += 1
-        
+
         return frames
 
 
 class RustParser(StackTraceParser):
     """Parser for Rust stack traces.
-    
+
     Format examples (backtrace style):
         thread 'main' panicked at 'index out of bounds', src/main.rs:42:5
         stack backtrace:
@@ -495,137 +508,141 @@ class RustParser(StackTraceParser):
                       at src/main.rs:42:5
            3: my_crate::main
                       at src/main.rs:10:1
-    
+
     Also handles panic messages and backtrace formats.
     """
-    
+
     # Pattern for panic line
     PANIC_PATTERN = re.compile(
         r"thread\s+'(?P<thread>[^']+)'?\s+panicked\s+(?:at\s+)?(?P<message>[^,]+)?,\s*(?P<file>[^:]+):(?P<line>\d+)(?::(?P<col>\d+))?",
-        re.IGNORECASE
+        re.IGNORECASE,
     )
-    
+
     # Pattern for stack frames
     FRAME_PATTERN = re.compile(
-        r'^\s*(?:(?P<frame_num>\d+):)?\s*(?P<func>[^\n]+?)'
-        r'(?:\n\s+at\s+(?P<file>[^:]+):(?P<line>\d+)(?::(?P<col>\d+))?)?',
-        re.MULTILINE
+        r"^\s*(?:(?P<frame_num>\d+):)?\s*(?P<func>[^\n]+?)"
+        r"(?:\n\s+at\s+(?P<file>[^:]+):(?P<line>\d+)(?::(?P<col>\d+))?)?",
+        re.MULTILINE,
     )
-    
+
     def detect_language(self, stacktrace: str) -> Language:
         """Detect Rust stack trace by characteristic patterns."""
         indicators = [
             re.compile(r"thread\s+'[^']+'\s+panicked"),
-            re.compile(r'\.rs:\d+'),
-            re.compile(r'rust_begin_unwind'),
-            re.compile(r'core::panicking'),
-            re.compile(r'stack backtrace:'),
+            re.compile(r"\.rs:\d+"),
+            re.compile(r"rust_begin_unwind"),
+            re.compile(r"core::panicking"),
+            re.compile(r"stack backtrace:"),
         ]
         return Language.RUST if any(p.search(stacktrace) for p in indicators) else Language.UNKNOWN
-    
+
     def extract_error_info(self, stacktrace: str) -> tuple[str, str]:
         """Extract error type and message from Rust stack trace."""
         match = self.PANIC_PATTERN.search(stacktrace)
         if match:
-            message = match.group('message').strip().strip("'")
-            return 'panic', message
-        
+            message = match.group("message").strip().strip("'")
+            return "panic", message
+
         # Look for panic message without location
         panic_match = re.search(r"panicked\s+(?:at\s+)?'([^']+)'", stacktrace)
         if panic_match:
-            return 'panic', panic_match.group(1)
-        
-        return 'panic', ''
-    
+            return "panic", panic_match.group(1)
+
+        return "panic", ""
+
     def parse(self, stacktrace: str) -> list[StackFrame]:
         """Parse Rust stack trace into frames."""
         frames = []
         frame_index = 0
-        
+
         # First, try to extract panic info as a special frame
         panic_match = self.PANIC_PATTERN.search(stacktrace)
         if panic_match:
-            file_path = panic_match.group('file')
-            line_number = int(panic_match.group('line')) if panic_match.group('line') else None
-            column = int(panic_match.group('col')) if panic_match.group('col') else None
-            
-            frames.append(StackFrame(
-                frame_index=frame_index,
-                function_name='<panic>',
-                file_path=file_path,
-                line_number=line_number,
-                column=column,
-                language=Language.RUST,
-                frame_type=FrameType.EXCEPTION_HANDLER,
-                raw_line=panic_match.group(0).strip(),
-            ))
+            file_path = panic_match.group("file")
+            line_number = int(panic_match.group("line")) if panic_match.group("line") else None
+            column = int(panic_match.group("col")) if panic_match.group("col") else None
+
+            frames.append(
+                StackFrame(
+                    frame_index=frame_index,
+                    function_name="<panic>",
+                    file_path=file_path,
+                    line_number=line_number,
+                    column=column,
+                    language=Language.RUST,
+                    frame_type=FrameType.EXCEPTION_HANDLER,
+                    raw_line=panic_match.group(0).strip(),
+                )
+            )
             frame_index += 1
-        
+
         # Parse stack frames - Rust backtrace format
         # Format: "   N: function_name\n              at file.rs:line:col"
         frame_regex = re.compile(
-            r'^\s*(?:(?P<frame_num>\d+):)\s*(?P<func>[^\n]+?)'
-            r'(?:\n\s+at\s+(?P<file>[^:\n]+):(?P<line>\d+)(?::(?P<col>\d+))?)?',
-            re.MULTILINE
+            r"^\s*(?:(?P<frame_num>\d+):)\s*(?P<func>[^\n]+?)"
+            r"(?:\n\s+at\s+(?P<file>[^:\n]+):(?P<line>\d+)(?::(?P<col>\d+))?)?",
+            re.MULTILINE,
         )
-        
+
         for match in frame_regex.finditer(stacktrace):
-            func_name = match.group('func').strip()
-            file_path = match.group('file')
-            line_number = int(match.group('line')) if match.group('line') else None
-            column = int(match.group('col')) if match.group('col') else None
-            
+            func_name = match.group("func").strip()
+            file_path = match.group("file")
+            line_number = int(match.group("line")) if match.group("line") else None
+            column = int(match.group("col")) if match.group("col") else None
+
             # Skip if no file path (runtime frames often don't have useful info)
             if not file_path:
                 continue
-            
+
             # Skip standard library frames from /rustc/ path for cleaner output
-            if file_path and '/rustc/' in file_path:
+            if file_path and "/rustc/" in file_path:
                 # Still include but mark as library
                 pass
-            
+
             # Parse function name for module::function pattern
             class_name = None
             module = None
-            
-            if '::' in func_name:
-                parts = func_name.rsplit('::', 1)
+
+            if "::" in func_name:
+                parts = func_name.rsplit("::", 1)
                 if len(parts) == 2:
                     module = parts[0]
                     func_name = parts[1]
-            
+
             # Determine frame type
             frame_type = FrameType.FUNCTION_CALL
-            if func_name == '<panic>' or 'panic' in func_name.lower():
+            if func_name == "<panic>" or "panic" in func_name.lower():
                 frame_type = FrameType.EXCEPTION_HANDLER
-            
-            frames.append(StackFrame(
-                frame_index=frame_index,
-                function_name=func_name,
-                class_name=class_name,
-                file_path=file_path,
-                line_number=line_number,
-                column=column,
-                language=Language.RUST,
-                frame_type=frame_type,
-                raw_line=match.group(0).strip(),
-                module=module,
-            ))
+
+            frames.append(
+                StackFrame(
+                    frame_index=frame_index,
+                    function_name=func_name,
+                    class_name=class_name,
+                    file_path=file_path,
+                    line_number=line_number,
+                    column=column,
+                    language=Language.RUST,
+                    frame_type=frame_type,
+                    raw_line=match.group(0).strip(),
+                    module=module,
+                )
+            )
             frame_index += 1
-        
+
         return frames
 
 
 class StackTraceParserFactory:
     """Factory for creating appropriate stack trace parsers."""
-    
+
     _parsers: dict[Language, type[StackTraceParser]] = {
         Language.PYTHON: PythonParser,
         Language.CPP: CppParser,
         Language.JAVA: JavaParser,
         Language.RUST: RustParser,
     }
-    
+
     @classmethod
     def get_parser(cls, language: Language) -> StackTraceParser:
         """Get parser for a specific language."""
@@ -633,11 +650,13 @@ class StackTraceParserFactory:
         if parser_class:
             return parser_class()
         raise ValueError(f"No parser available for language: {language}")
-    
+
     @classmethod
-    def detect_and_parse(cls, stacktrace: str) -> tuple[StackTraceParser, list[StackFrame], Language]:
+    def detect_and_parse(
+        cls, stacktrace: str
+    ) -> tuple[StackTraceParser, list[StackFrame], Language]:
         """Auto-detect language and parse stack trace.
-        
+
         Returns:
             Tuple of (parser, frames, detected_language)
         """
@@ -647,10 +666,10 @@ class StackTraceParserFactory:
             if parser.detect_language(stacktrace) != Language.UNKNOWN:
                 frames = parser.parse(stacktrace)
                 return parser, frames, language
-        
+
         # Fallback: return unknown
         return PythonParser(), [], Language.UNKNOWN
-    
+
     @classmethod
     def get_all_parsers(cls) -> dict[Language, StackTraceParser]:
         """Get all available parsers."""

--- a/ast_rag/stack_trace/service.py
+++ b/ast_rag/stack_trace/service.py
@@ -13,7 +13,6 @@ Main service class that:
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 from typing import Any, Optional
 
@@ -31,12 +30,7 @@ from .models import (
     StackTraceReport,
 )
 from .parsers import (
-    StackTraceParser,
     StackTraceParserFactory,
-    PythonParser,
-    CppParser,
-    JavaParser,
-    RustParser,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,44 +39,79 @@ logger = logging.getLogger(__name__)
 # Error category mappings for root cause analysis
 ERROR_CATEGORIES: dict[str, list[str]] = {
     "null_pointer": [
-        "NullPointerException", "NullReferenceException", "NoneType", 
-        "null pointer", "None has no attribute", "undefined is not a function"
+        "NullPointerException",
+        "NullReferenceException",
+        "NoneType",
+        "null pointer",
+        "None has no attribute",
+        "undefined is not a function",
     ],
     "out_of_bounds": [
-        "IndexOutOfBoundsException", "IndexError", "out of range", 
-        "out of bounds", "array index", "slice index", "bounds check"
+        "IndexOutOfBoundsException",
+        "IndexError",
+        "out of range",
+        "out of bounds",
+        "array index",
+        "slice index",
+        "bounds check",
     ],
     "type_error": [
-        "TypeError", "ClassCastException", "type mismatch", 
-        "cannot convert", "incompatible type", "no matching function"
+        "TypeError",
+        "ClassCastException",
+        "type mismatch",
+        "cannot convert",
+        "incompatible type",
+        "no matching function",
     ],
     "value_error": [
-        "ValueError", "IllegalArgumentException", "invalid argument",
-        "invalid value", "invalid literal", "format error"
+        "ValueError",
+        "IllegalArgumentException",
+        "invalid argument",
+        "invalid value",
+        "invalid literal",
+        "format error",
     ],
     "key_error": [
-        "KeyError", "NoSuchElementException", "key not found",
-        "missing key", "map key", "hash key"
+        "KeyError",
+        "NoSuchElementException",
+        "key not found",
+        "missing key",
+        "map key",
+        "hash key",
     ],
     "attribute_error": [
-        "AttributeError", "MissingPropertyException", "has no attribute",
-        "property not found", "member not found"
+        "AttributeError",
+        "MissingPropertyException",
+        "has no attribute",
+        "property not found",
+        "member not found",
     ],
     "file_error": [
-        "FileNotFoundError", "IOException", "file not found",
-        "cannot open file", "access denied", "permission denied"
+        "FileNotFoundError",
+        "IOException",
+        "file not found",
+        "cannot open file",
+        "access denied",
+        "permission denied",
     ],
     "memory_error": [
-        "MemoryError", "OutOfMemoryError", "out of memory",
-        "memory allocation", "heap space", "stack overflow"
+        "MemoryError",
+        "OutOfMemoryError",
+        "out of memory",
+        "memory allocation",
+        "heap space",
+        "stack overflow",
     ],
     "concurrency": [
-        "ConcurrentModificationException", "Deadlock", "RaceCondition",
-        "thread", "lock", "synchronization", "mutex"
+        "ConcurrentModificationException",
+        "Deadlock",
+        "RaceCondition",
+        "thread",
+        "lock",
+        "synchronization",
+        "mutex",
     ],
-    "panic": [
-        "panic", "unreachable", "assertion failed", "unwrap failed"
-    ],
+    "panic": ["panic", "unreachable", "assertion failed", "unwrap failed"],
 }
 
 # Severity mappings
@@ -102,20 +131,20 @@ ERROR_SEVERITY: dict[str, str] = {
 
 class StackTraceService:
     """Service for analyzing stack traces and mapping to AST.
-    
+
     This service provides comprehensive stack trace analysis:
     1. Parse stack traces from multiple languages
     2. Map each frame to AST nodes in the graph database
     3. Retrieve code snippets for context
     4. Analyze root cause and suggest fixes
     5. Find similar issues in the codebase
-    
+
     Usage:
         service = StackTraceService(driver, embedding_manager)
         report = service.analyze(stacktrace_text)
         print(report.to_markdown())
     """
-    
+
     def __init__(
         self,
         driver: Driver,
@@ -123,7 +152,7 @@ class StackTraceService:
         codebase_root: Optional[str] = None,
     ) -> None:
         """Initialize the stack trace service.
-        
+
         Args:
             driver: Neo4j driver for graph database access
             embedding_manager: EmbeddingManager for semantic search
@@ -133,27 +162,27 @@ class StackTraceService:
         self._api = ASTRagAPI(driver, embedding_manager)
         self._embed = embedding_manager
         self._codebase_root = Path(codebase_root) if codebase_root else None
-        
+
         # Initialize parsers
         self._parsers = StackTraceParserFactory.get_all_parsers()
-    
+
     def analyze(self, stacktrace: str) -> StackTraceReport:
         """Analyze a stack trace and generate a comprehensive report.
-        
+
         This is the main entry point for stack trace analysis.
-        
+
         Args:
             stacktrace: Raw stack trace text
-            
+
         Returns:
             StackTraceReport with full analysis
         """
         # Step 1: Detect language and parse frames
         parser, frames, detected_language = StackTraceParserFactory.detect_and_parse(stacktrace)
-        
+
         # Step 2: Extract error info
         error_type, error_message = parser.extract_error_info(stacktrace)
-        
+
         # Step 3: Create initial report
         report = StackTraceReport(
             error_type=error_type,
@@ -162,48 +191,48 @@ class StackTraceService:
             call_chain=frames,
             total_frames=len(frames),
         )
-        
+
         # Step 4: Map frames to AST nodes
         mapped_count = self._map_frames_to_ast(frames)
         report.mapped_frames = mapped_count
-        
+
         # Step 5: Retrieve code snippets for mapped frames
         self._retrieve_code_snippets(frames)
-        
+
         # Step 6: Analyze root cause
         report.root_cause = self._analyze_root_cause(error_type, error_message, frames)
-        
+
         # Step 7: Find similar issues
         report.similar_issues = self._find_similar_issues(error_type, error_message, frames)
-        
+
         # Step 8: Generate summary
         report.summary = self._generate_summary(report)
-        
+
         # Step 9: Analyze text with existing API for additional context
         text_results = self._analyze_with_text_api(stacktrace)
         if text_results and not report.similar_issues:
             report.similar_issues = self._convert_text_results_to_issues(text_results)
-        
+
         return report
-    
+
     def _map_frames_to_ast(self, frames: list[StackFrame]) -> int:
         """Map stack frames to AST nodes in the graph database.
-        
+
         For each frame, attempts to find the corresponding AST node
         using file path, line number, and function name.
-        
+
         Args:
             frames: List of StackFrame objects to map
-            
+
         Returns:
             Number of successfully mapped frames
         """
         mapped_count = 0
-        
+
         for frame in frames:
             if not frame.file_path and not frame.function_name:
                 continue
-            
+
             # Strategy 1: Find by file path and line number
             if frame.file_path and frame.line_number:
                 node = self._find_node_by_location(
@@ -216,7 +245,7 @@ class StackTraceService:
                     frame.ast_node_qualified_name = node.qualified_name
                     mapped_count += 1
                     continue
-            
+
             # Strategy 2: Find by function/class name
             if frame.function_name:
                 node = self._find_node_by_name(
@@ -229,7 +258,7 @@ class StackTraceService:
                     frame.ast_node_qualified_name = node.qualified_name
                     mapped_count += 1
                     continue
-            
+
             # Strategy 3: Semantic search by frame context
             if frame.function_name or frame.raw_line:
                 node = self._find_node_by_semantic_search(frame)
@@ -237,9 +266,9 @@ class StackTraceService:
                     frame.ast_node_id = node.id
                     frame.ast_node_qualified_name = node.qualified_name
                     mapped_count += 1
-        
+
         return mapped_count
-    
+
     def _find_node_by_location(
         self,
         file_path: str,
@@ -247,18 +276,18 @@ class StackTraceService:
         language: Language,
     ) -> Optional[ASTNode]:
         """Find AST node by file path and line number.
-        
+
         Args:
             file_path: Source file path
             line_number: Line number (1-indexed)
             language: Programming language
-            
+
         Returns:
             ASTNode if found, None otherwise
         """
         # Convert our Language enum to model's Language enum
         lang_value = self._convert_language(language)
-        
+
         cypher = """
 MATCH (n)
 WHERE n.valid_to IS NULL
@@ -271,8 +300,8 @@ ORDER BY n.start_line DESC
 LIMIT 1
 """
         # Normalize file path for matching
-        normalized_path = file_path.replace('\\', '/')
-        
+        normalized_path = file_path.replace("\\", "/")
+
         with self._driver.session() as session:
             result = session.run(
                 cypher,
@@ -283,9 +312,9 @@ LIMIT 1
             record = result.single()
             if record:
                 return self._record_to_node(dict(record["n"]))
-        
+
         return None
-    
+
     def _find_node_by_name(
         self,
         function_name: str,
@@ -293,20 +322,20 @@ LIMIT 1
         language: Language,
     ) -> Optional[ASTNode]:
         """Find AST node by function/class name.
-        
+
         Args:
             function_name: Function or method name
             class_name: Optional class name for methods
             language: Programming language
-            
+
         Returns:
             ASTNode if found, None otherwise
         """
         lang_value = self._convert_language(language)
-        
+
         # Build qualified name if class is provided
         qualified_name = f"{class_name}.{function_name}" if class_name else function_name
-        
+
         # Try exact match first
         cypher = """
 MATCH (n)
@@ -327,7 +356,7 @@ LIMIT 1
             record = result.single()
             if record:
                 return self._record_to_node(dict(record["n"]))
-        
+
         # Try contains match
         cypher = """
 MATCH (n)
@@ -348,15 +377,15 @@ LIMIT 1
             record = result.single()
             if record:
                 return self._record_to_node(dict(record["n"]))
-        
+
         return None
-    
+
     def _find_node_by_semantic_search(self, frame: StackFrame) -> Optional[ASTNode]:
         """Find AST node by semantic search on frame context.
-        
+
         Args:
             frame: StackFrame to search for
-            
+
         Returns:
             ASTNode if found, None otherwise
         """
@@ -368,30 +397,30 @@ LIMIT 1
             query_parts.append(frame.class_name)
         if frame.module:
             query_parts.append(frame.module)
-        
+
         if not query_parts:
             return None
-        
+
         query = " ".join(query_parts)
-        
+
         # Filter by language
         lang_filter = self._convert_language(frame.language).value
-        
+
         try:
             results = self._api.search_semantic(query, limit=5, lang=lang_filter)
             if results:
                 return results[0].node
         except Exception as e:
             logger.warning(f"Semantic search failed for frame {frame.function_name}: {e}")
-        
+
         return None
-    
+
     def _retrieve_code_snippets(self, frames: list[StackFrame]) -> None:
         """Retrieve code snippets for mapped frames.
-        
+
         Populates the code_snippet field for each frame that has
         been mapped to an AST node.
-        
+
         Args:
             frames: List of StackFrame objects
         """
@@ -407,7 +436,7 @@ LIMIT 1
                     end_line,
                 )
                 frame.code_snippet = snippet
-    
+
     def _analyze_root_cause(
         self,
         error_type: str,
@@ -415,28 +444,28 @@ LIMIT 1
         frames: list[StackFrame],
     ) -> RootCause:
         """Analyze the root cause of the error.
-        
+
         Args:
             error_type: Type of error (e.g., NullPointerException)
             error_message: Error message text
             frames: List of stack frames
-            
+
         Returns:
             RootCause analysis object
         """
         # Determine error category
         category = self._categorize_error(error_type, error_message)
         severity = ERROR_SEVERITY.get(category, "medium")
-        
+
         # Find frames related to the error (usually the first few)
         related_frames = [f.frame_index for f in frames[:3]]
-        
+
         # Generate likely cause explanation
         likely_cause = self._generate_likely_cause(category, error_type, error_message, frames)
-        
+
         # Generate suggested fix
         suggested_fix = self._generate_suggested_fix(category, error_type, frames)
-        
+
         # Calculate confidence based on how well we could categorize
         confidence = 0.5  # Base confidence
         if category and category != "unknown":
@@ -445,7 +474,7 @@ LIMIT 1
             confidence += 0.2
         if error_message and len(error_message) > 10:
             confidence += 0.1
-        
+
         return RootCause(
             error_type=error_type,
             error_message=error_message,
@@ -456,25 +485,25 @@ LIMIT 1
             confidence=min(confidence, 1.0),
             related_frames=related_frames,
         )
-    
+
     def _categorize_error(self, error_type: str, error_message: str) -> str:
         """Categorize the error type.
-        
+
         Args:
             error_type: Error type string
             error_message: Error message string
-            
+
         Returns:
             Category string (e.g., 'null_pointer', 'out_of_bounds')
         """
         text = f"{error_type} {error_message}".lower()
-        
+
         for category, keywords in ERROR_CATEGORIES.items():
             if any(keyword.lower() in text for keyword in keywords):
                 return category
-        
+
         return "unknown"
-    
+
     def _generate_likely_cause(
         self,
         category: str,
@@ -483,13 +512,13 @@ LIMIT 1
         frames: list[StackFrame],
     ) -> str:
         """Generate human-readable likely cause explanation.
-        
+
         Args:
             category: Error category
             error_type: Error type
             error_message: Error message
             frames: Stack frames
-            
+
         Returns:
             Human-readable explanation
         """
@@ -500,51 +529,51 @@ LIMIT 1
                 f"contains null/None instead. Check the value at {frames[0].file_path}:{frames[0].line_number if frames and frames[0].line_number else 'unknown location'}."
             ),
             "out_of_bounds": (
-                f"An array/list index was out of valid range. "
-                f"The index used was likely beyond the array bounds or negative. "
-                f"Verify array length before accessing elements."
+                "An array/list index was out of valid range. "
+                "The index used was likely beyond the array bounds or negative. "
+                "Verify array length before accessing elements."
             ),
             "type_error": (
-                f"An operation was performed on an incompatible type. "
-                f"Check that the types of operands match the expected types for this operation."
+                "An operation was performed on an incompatible type. "
+                "Check that the types of operands match the expected types for this operation."
             ),
             "value_error": (
-                f"A function received an argument with the correct type but invalid value. "
-                f"Validate input values before processing."
+                "A function received an argument with the correct type but invalid value. "
+                "Validate input values before processing."
             ),
             "key_error": (
-                f"A dictionary/map key was not found. "
-                f"The key being accessed does not exist in the collection. "
-                f"Use .get() method or check key existence before access."
+                "A dictionary/map key was not found. "
+                "The key being accessed does not exist in the collection. "
+                "Use .get() method or check key existence before access."
             ),
             "attribute_error": (
-                f"An attribute or method was accessed on an object that doesn't have it. "
-                f"Verify the object type and available methods."
+                "An attribute or method was accessed on an object that doesn't have it. "
+                "Verify the object type and available methods."
             ),
             "file_error": (
-                f"A file operation failed. The file may not exist, or there may be "
-                f"permission issues. Check file paths and permissions."
+                "A file operation failed. The file may not exist, or there may be "
+                "permission issues. Check file paths and permissions."
             ),
             "memory_error": (
-                f"The program ran out of memory. This could be due to a memory leak, "
-                f"large data structures, or insufficient system memory."
+                "The program ran out of memory. This could be due to a memory leak, "
+                "large data structures, or insufficient system memory."
             ),
             "concurrency": (
-                f"A threading or synchronization issue occurred. "
-                f"This could be a race condition, deadlock, or concurrent modification."
+                "A threading or synchronization issue occurred. "
+                "This could be a race condition, deadlock, or concurrent modification."
             ),
             "panic": (
-                f"The program encountered an unrecoverable error and panicked. "
-                f"This is often due to an assertion failure or explicit panic call."
+                "The program encountered an unrecoverable error and panicked. "
+                "This is often due to an assertion failure or explicit panic call."
             ),
             "unknown": (
                 f"An error of type '{error_type}' occurred: {error_message}. "
                 f"Review the stack trace and code context for more details."
             ),
         }
-        
+
         return explanations.get(category, explanations["unknown"])
-    
+
     def _generate_suggested_fix(
         self,
         category: str,
@@ -552,12 +581,12 @@ LIMIT 1
         frames: list[StackFrame],
     ) -> str:
         """Generate suggested fix for the error.
-        
+
         Args:
             category: Error category
             error_type: Error type
             frames: Stack frames
-            
+
         Returns:
             Suggested fix description
         """
@@ -629,9 +658,9 @@ LIMIT 1
                 "4. Search for similar issues in the codebase"
             ),
         }
-        
+
         return fixes.get(category, fixes["unknown"])
-    
+
     def _find_similar_issues(
         self,
         error_type: str,
@@ -639,79 +668,83 @@ LIMIT 1
         frames: list[StackFrame],
     ) -> list[SimilarIssue]:
         """Find similar issues in the codebase.
-        
+
         Uses semantic search to find similar error patterns or
         related code sections.
-        
+
         Args:
             error_type: Error type
             error_message: Error message
             frames: Stack frames
-            
+
         Returns:
             List of SimilarIssue objects
         """
         similar = []
-        
+
         # Search by error type
         query = f"{error_type} error handling exception"
         try:
             results = self._api.search_semantic(query, limit=5)
             for i, result in enumerate(results[:3]):
                 node = result.node
-                similar.append(SimilarIssue(
-                    issue_id=f"similar_{i}",
-                    title=f"Similar code pattern in {node.qualified_name}",
-                    location=f"{node.file_path}:{node.start_line}",
-                    similarity_score=result.score,
-                    source="internal",
-                ))
+                similar.append(
+                    SimilarIssue(
+                        issue_id=f"similar_{i}",
+                        title=f"Similar code pattern in {node.qualified_name}",
+                        location=f"{node.file_path}:{node.start_line}",
+                        similarity_score=result.score,
+                        source="internal",
+                    )
+                )
         except Exception as e:
             logger.warning(f"Similar issue search failed: {e}")
-        
+
         return similar
-    
+
     def _generate_summary(self, report: StackTraceReport) -> str:
         """Generate a human-readable summary of the analysis.
-        
+
         Args:
             report: StackTraceReport object
-            
+
         Returns:
             Summary string
         """
         parts = []
-        
+
         # Error summary
         parts.append(f"Error: {report.error_type}")
         if report.message:
             parts.append(f"Message: {report.message}")
-        
+
         # Language info
         parts.append(f"Language: {report.language.value}")
-        
+
         # Frame summary
-        parts.append(f"Stack frames: {report.total_frames} total, {report.mapped_frames} mapped to AST")
-        
+        parts.append(
+            f"Stack frames: {report.total_frames} total, {report.mapped_frames} mapped to AST"
+        )
+
         # Root cause
         if report.root_cause:
             rc = report.root_cause
             parts.append(f"Root cause: {rc.likely_cause or 'Analysis pending'}")
             if rc.suggested_fix:
                 parts.append(f"Suggested fix: {rc.suggested_fix[:100]}...")
-        
+
         # Similar issues
         if report.similar_issues:
             parts.append(f"Found {len(report.similar_issues)} similar issues in codebase")
-        
+
         return " | ".join(parts)
-    
+
     def _analyze_with_text_api(self, stacktrace: str) -> list[Any]:
         """Use existing analyze_text API for additional context.
-        
+
         Args:
             stacktrace: Raw stack trace text
-            
+
         Returns:
             List of search results
         """
@@ -721,38 +754,40 @@ LIMIT 1
         except Exception as e:
             logger.warning(f"analyze_text failed: {e}")
             return []
-    
+
     def _convert_text_results_to_issues(
         self,
         results: list[Any],
     ) -> list[SimilarIssue]:
         """Convert analyze_text results to SimilarIssue objects.
-        
+
         Args:
             results: Results from analyze_text API
-            
+
         Returns:
             List of SimilarIssue objects
         """
         issues = []
         for i, result in enumerate(results[:5]):
-            node = result.node if hasattr(result, 'node') else result
-            if hasattr(node, 'file_path'):
-                issues.append(SimilarIssue(
-                    issue_id=f"text_result_{i}",
-                    title=f"Related code: {node.qualified_name if hasattr(node, 'qualified_name') else 'Unknown'}",
-                    location=f"{node.file_path}:{node.start_line if hasattr(node, 'start_line') else '?'}",
-                    similarity_score=result.score if hasattr(result, 'score') else 0.5,
-                    source="semantic_search",
-                ))
+            node = result.node if hasattr(result, "node") else result
+            if hasattr(node, "file_path"):
+                issues.append(
+                    SimilarIssue(
+                        issue_id=f"text_result_{i}",
+                        title=f"Related code: {node.qualified_name if hasattr(node, 'qualified_name') else 'Unknown'}",
+                        location=f"{node.file_path}:{node.start_line if hasattr(node, 'start_line') else '?'}",
+                        similarity_score=result.score if hasattr(result, "score") else 0.5,
+                        source="semantic_search",
+                    )
+                )
         return issues
-    
+
     def _convert_language(self, language: Language) -> ModelLanguage:
         """Convert stack_trace.Language to models.Language.
-        
+
         Args:
             language: Language from stack_trace module
-            
+
         Returns:
             Language from models module
         """
@@ -764,13 +799,13 @@ LIMIT 1
             Language.UNKNOWN: ModelLanguage.PYTHON,  # Default fallback
         }
         return mapping.get(language, ModelLanguage.PYTHON)
-    
+
     def _record_to_node(self, record: dict) -> ASTNode:
         """Convert Neo4j record to ASTNode.
-        
+
         Args:
             record: Neo4j record dict
-            
+
         Returns:
             ASTNode object
         """
@@ -791,19 +826,19 @@ LIMIT 1
             valid_from=r.get("valid_from", "INIT"),
             valid_to=r.get("valid_to"),
         )
-    
+
     def analyze_from_file(self, file_path: str) -> StackTraceReport:
         """Analyze a stack trace from a file.
-        
+
         Args:
             file_path: Path to file containing stack trace
-            
+
         Returns:
             StackTraceReport object
         """
         path = Path(file_path)
         if not path.exists():
             raise FileNotFoundError(f"Stack trace file not found: {file_path}")
-        
+
         stacktrace = path.read_text(encoding="utf-8", errors="replace")
         return self.analyze(stacktrace)

--- a/ast_rag/summarizer.py
+++ b/ast_rag/summarizer.py
@@ -1,0 +1,3 @@
+"""Compatibility shim for the legacy summarizer module path."""
+
+from ast_rag.services.summarizer_service import *  # noqa: F403

--- a/ast_rag/utils/file_cache.py
+++ b/ast_rag/utils/file_cache.py
@@ -41,7 +41,7 @@ def _get_git_hash(file_path: str, repo_path: str = ".") -> Optional[str]:
             ["git", "-C", repo_path, "ls-files", "-s", file_path],
             capture_output=True,
             text=True,
-            timeout=5
+            timeout=5,
         )
         if result.returncode == 0 and result.stdout.strip():
             # Format: "mode hash stage path"
@@ -88,7 +88,7 @@ class FileCache:
             result = subprocess.run(
                 ["git", "-C", self.root_path, "rev-parse", "--git-dir"],
                 capture_output=True,
-                timeout=5
+                timeout=5,
             )
             if result.returncode == 0:
                 self._git_repo = self.root_path

--- a/ast_rag/utils/output.py
+++ b/ast_rag/utils/output.py
@@ -156,9 +156,7 @@ class HumanFormatter(OutputFormatter):
             )
 
             if snippet and api:
-                code = api.get_code_snippet(
-                    node.file_path, node.start_line, node.end_line
-                )
+                code = api.get_code_snippet(node.file_path, node.start_line, node.end_line)
                 if code:
                     lang_map = {
                         "java": "java",

--- a/ast_rag/utils/parse_cache.py
+++ b/ast_rag/utils/parse_cache.py
@@ -47,7 +47,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
 import sqlite3
 import time
 from typing import Any, Callable, Optional
@@ -60,6 +59,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # LazyTree
 # ---------------------------------------------------------------------------
+
 
 class LazyTree:
     """Thin proxy that defers tree loading until first attribute access.
@@ -139,6 +139,7 @@ class LazyTree:
 # ---------------------------------------------------------------------------
 # ParseCache  (in-memory, default backend)
 # ---------------------------------------------------------------------------
+
 
 class ParseCache:
     """Content-addressed in-memory cache for tree-sitter parse trees.
@@ -223,7 +224,7 @@ class ParseCache:
         content_hash = self.hash_source(source)
         # Create a no-op loader — tree is already available.
         lazy = LazyTree(loader=lambda t=tree: t)
-        object.__setattr__(lazy, "_tree", tree)   # pre-populate → eager
+        object.__setattr__(lazy, "_tree", tree)  # pre-populate → eager
         object.__setattr__(lazy, "_hash", content_hash)
         self._store[abs_path] = lazy
         logger.debug("ParseCache PUT : %s", abs_path)
@@ -309,9 +310,7 @@ class SQLiteParseCache:
         self._db_path = db_path
         self._hits: int = 0
         self._misses: int = 0
-        self._conn: sqlite3.Connection = sqlite3.connect(
-            db_path, check_same_thread=False
-        )
+        self._conn: sqlite3.Connection = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.executescript(_SCHEMA)
         self._conn.commit()
         logger.debug("SQLiteParseCache opened: %s", db_path)
@@ -402,9 +401,7 @@ class SQLiteParseCache:
         Args:
             abs_path: Absolute path of the file to evict.
         """
-        cur = self._conn.execute(
-            "DELETE FROM parse_cache WHERE file_path = ?", (abs_path,)
-        )
+        cur = self._conn.execute("DELETE FROM parse_cache WHERE file_path = ?", (abs_path,))
         self._conn.commit()
         if cur.rowcount:
             logger.debug("SQLiteParseCache EVICT: %s", abs_path)

--- a/ast_rag/watcher.py
+++ b/ast_rag/watcher.py
@@ -1,0 +1,4 @@
+"""Compatibility shim for the legacy watcher module path."""
+
+from ast_rag.services.watcher_service import *  # noqa: F403
+from ast_rag.services.watcher_service import main  # noqa: F401

--- a/tests/generate_ground_truth.py
+++ b/tests/generate_ground_truth.py
@@ -45,16 +45,16 @@ class GroundTruthGenerator:
 
     def generate_query_for_node(self, node: Dict[str, Any], node_type: str) -> Dict[str, Any]:
         """Generate a natural language query for a specific node."""
-        name = node.get('name', '')
-        qualified_name = node.get('qualified_name', '')
+        name = node.get("name", "")
+        qualified_name = node.get("qualified_name", "")
 
-        if node_type == 'Class':
+        if node_type == "Class":
             query = f"class that handles {name}"
-        elif node_type == 'Function':
+        elif node_type == "Function":
             query = f"function named {name}"
-        elif node_type == 'Method':
+        elif node_type == "Method":
             # Extract class name from qualified_name (e.g., "EmbeddingManager.hybrid_search")
-            parts = qualified_name.split('.')
+            parts = qualified_name.split(".")
             if len(parts) >= 2:
                 class_name = parts[0]
                 method_name = parts[-1]
@@ -64,28 +64,25 @@ class GroundTruthGenerator:
         else:
             query = f"{node_type.lower()} named {name}"
 
-        return {
-            "query": query,
-            "relevant_ids": [
-                {"id": node['id'], "score": 3}
-            ]
-        }
+        return {"query": query, "relevant_ids": [{"id": node["id"], "score": 3}]}
 
-    def generate_ground_truth(self, output_path: str = "ground_truth_queries.json", num_nodes_per_type: int = 7) -> None:
+    def generate_ground_truth(
+        self, output_path: str = "ground_truth_queries.json", num_nodes_per_type: int = 7
+    ) -> None:
         """Generate ground truth queries for random nodes."""
         # Get random nodes of each type
-        classes = self.get_random_nodes('Class', num_nodes_per_type)
-        functions = self.get_random_nodes('Function', num_nodes_per_type)
-        methods = self.get_random_nodes('Method', num_nodes_per_type)
+        classes = self.get_random_nodes("Class", num_nodes_per_type)
+        functions = self.get_random_nodes("Function", num_nodes_per_type)
+        methods = self.get_random_nodes("Method", num_nodes_per_type)
 
         # Combine all nodes
         all_entries = []
         for node in classes:
-            all_entries.append((node, 'Class'))
+            all_entries.append((node, "Class"))
         for node in functions:
-            all_entries.append((node, 'Function'))
+            all_entries.append((node, "Function"))
         for node in methods:
-            all_entries.append((node, 'Method'))
+            all_entries.append((node, "Method"))
 
         random.shuffle(all_entries)
         all_entries = all_entries[:20]  # Take up to 20 total
@@ -99,10 +96,10 @@ class GroundTruthGenerator:
         # Save to JSON file
         output = {
             "description": "Ground truth queries generated from actual Neo4j data",
-            "queries": queries
+            "queries": queries,
         }
 
-        with open(output_path, 'w') as f:
+        with open(output_path, "w") as f:
             json.dump(output, f, indent=2)
 
         logger.info(f"Generated {len(queries)} ground truth queries in {output_path}")
@@ -116,7 +113,7 @@ def main():
 
     # Load configuration
     logger.info("Loading config from ast_rag_config.json")
-    with open('ast_rag_config.json', 'r') as f:
+    with open("ast_rag_config.json", "r") as f:
         config_data = json.load(f)
     cfg = ProjectConfig(**config_data)
 

--- a/tests/test_ast_cache.py
+++ b/tests/test_ast_cache.py
@@ -24,7 +24,7 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from ast_rag.parse_cache import LazyTree, ParseCache, SQLiteParseCache
+from ast_rag.utils.parse_cache import LazyTree, ParseCache, SQLiteParseCache
 from ast_rag.services.parsing.parser_manager import ParserManager
 
 
@@ -70,7 +70,7 @@ class TestLazyTree:
             called.append(1)
             return sentinel
 
-        lazy = LazyTree(loader)
+        _ = LazyTree(loader)
         assert called == [], "loader must not be called at construction"
 
     def test_first_attribute_access_triggers_load(self):
@@ -182,7 +182,11 @@ class TestParseCacheUnit:
         sentinel = _make_sentinel_tree()
         cache.put("/f.py", b"src", sentinel)
         called = []
-        loader = lambda: called.append(1) or _make_sentinel_tree()
+
+        def loader():
+            called.append(1)
+            return _make_sentinel_tree()
+
         lazy = cache.get("/f.py", b"src", loader=loader)
         assert lazy is not None
         _ = lazy.resolve()
@@ -246,7 +250,10 @@ class TestSQLiteParseCache:
         try:
             cache = SQLiteParseCache(db)
             sentinel = _make_sentinel_tree()
-            loader = lambda: sentinel
+
+            def loader():
+                return sentinel
+
             assert cache.get("/f.py", b"src", loader=loader) is None
         finally:
             if os.path.exists(db):

--- a/tests/test_ast_cache.py
+++ b/tests/test_ast_cache.py
@@ -32,6 +32,7 @@ from ast_rag.services.parsing.parser_manager import ParserManager
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _tmp(suffix: str, content: bytes) -> str:
     fh = tempfile.NamedTemporaryFile(suffix=suffix, delete=False, mode="wb")
     fh.write(content)
@@ -56,6 +57,7 @@ def _make_sentinel_tree():
 # ===========================================================================
 # Unit tests: LazyTree
 # ===========================================================================
+
 
 class TestLazyTree:
     """Test LazyTree without involving any real parsing or storage."""
@@ -131,6 +133,7 @@ class TestLazyTree:
 # ===========================================================================
 # Unit tests: ParseCache in complete isolation (no ParserManager, no tree-sitter)
 # ===========================================================================
+
 
 class TestParseCacheUnit:
     """Test ParseCache directly without involving any parsing."""
@@ -214,8 +217,8 @@ class TestParseCacheUnit:
     def test_stats_hit_rate_calculation(self):
         cache = ParseCache()
         cache.put("/f.py", b"src", _make_sentinel_tree())
-        cache.get("/f.py", b"src")   # HIT
-        cache.get("/f.py", b"other") # MISS (hash mismatch)
+        cache.get("/f.py", b"src")  # HIT
+        cache.get("/f.py", b"other")  # MISS (hash mismatch)
         s = cache.stats()
         assert s["hits"] == 1
         assert s["misses"] == 1
@@ -233,6 +236,7 @@ class TestParseCacheUnit:
 # ===========================================================================
 # Unit tests: SQLiteParseCache
 # ===========================================================================
+
 
 class TestSQLiteParseCache:
     """Test SQLiteParseCache — persistence, interface parity, and observability."""
@@ -268,6 +272,7 @@ class TestSQLiteParseCache:
             cache.put("/f.py", b"src", sentinel)
 
             resolved = []
+
             def loader():
                 resolved.append(1)
                 return sentinel
@@ -348,7 +353,7 @@ class TestSQLiteParseCache:
             sentinel = _make_sentinel_tree()
             cache = SQLiteParseCache(db)
             cache.put("/f.py", b"src", sentinel)
-            cache.get("/f.py", b"src", loader=lambda: sentinel)        # HIT
+            cache.get("/f.py", b"src", loader=lambda: sentinel)  # HIT
             cache.get("/f.py", b"different", loader=lambda: sentinel)  # MISS
             s = cache.stats()
             assert s["hits"] == 1
@@ -361,6 +366,7 @@ class TestSQLiteParseCache:
 # ===========================================================================
 # Integration tests: ParserManager with in-memory ParseCache
 # ===========================================================================
+
 
 class TestParserManagerIntegration:
     """Verify ParserManager delegates to ParseCache (no inline cache logic)."""
@@ -447,16 +453,21 @@ class TestParserManagerIntegration:
 # Integration tests: ParserManager with SQLiteParseCache
 # ===========================================================================
 
+
 class TestParserManagerSQLite:
     """ParserManager with SQLite backend — persistence across two instances."""
 
     def test_factory_creates_sqlite_cache_from_config(self):
         db = _tmp_db()
         try:
-            pm = ParserManager(config={"parse_cache": {
-                "persistence_enabled": True,
-                "db_path": db,
-            }})
+            pm = ParserManager(
+                config={
+                    "parse_cache": {
+                        "persistence_enabled": True,
+                        "db_path": db,
+                    }
+                }
+            )
             assert isinstance(pm._cache, SQLiteParseCache)
         finally:
             if os.path.exists(db):
@@ -493,6 +504,7 @@ class TestParserManagerSQLite:
 # ===========================================================================
 # Worker resolve tests: parse_file(resolve=True)
 # ===========================================================================
+
 
 class TestWorkerResolve:
     """parse_file(resolve=True) must return a plain Tree, not a LazyTree.

--- a/tests/test_phase2.py
+++ b/tests/test_phase2.py
@@ -29,6 +29,7 @@ print()
 
 results = {"passed": 0, "failed": 0, "tests": []}
 
+
 def test(name, condition, details=""):
     status = "✅ PASS" if condition else "❌ FAIL"
     results["tests"].append((name, status, details))
@@ -40,6 +41,7 @@ def test(name, condition, details=""):
     if details and not condition:
         print(f"          {details}")
 
+
 # ============================================================================
 # TEST 1: StandardResult Model
 # ============================================================================
@@ -50,6 +52,7 @@ print("=" * 80)
 print("\n1.1 StandardResult class exists...")
 try:
     from ast_rag.models import StandardResult
+
     result = StandardResult(
         id="test123",
         name="testMethod",
@@ -73,6 +76,7 @@ except Exception as e:
 print("\n1.2 ASTNode.to_standard_result()...")
 try:
     from ast_rag.models import ASTNode, NodeKind, Language
+
     node = ASTNode(
         id="node1",
         name="myFunction",
@@ -83,7 +87,7 @@ try:
         start_line=42,
         end_line=85,
         start_byte=1000,  # Required field
-        end_byte=2000,    # Required field
+        end_byte=2000,  # Required field
     )
     std_result = node.to_standard_result(score=0.9)
     test("to_standard_result() exists", std_result is not None)
@@ -97,7 +101,7 @@ try:
     # Check if MCP tools use StandardResult
     with open("ast_rag/ast_rag_mcp.py", "r") as f:
         content = f.read()
-    
+
     test("find_references uses StandardResult", "StandardResult" in content)
     test("semantic_search uses StandardResult", "StandardResult" in content)
     test("find_callers uses StandardResult", "StandardResult" in content)
@@ -117,9 +121,10 @@ print("\n2.1 compute_diff_for_commits has dry_run...")
 try:
     from ast_rag.services.graph_updater_service import compute_diff_for_commits
     import inspect
+
     sig = inspect.signature(compute_diff_for_commits)
     params = list(sig.parameters.keys())
-    
+
     test("dry_run parameter exists", "dry_run" in params)
     test("max_changed_nodes parameter exists", "max_changed_nodes" in params)
 
@@ -137,7 +142,9 @@ try:
         test("  - has 'exceeds_limit' key", "exceeds_limit" in result)
     except Exception as git_err:
         # Skip if not enough commits (e.g. only 1 commit in repo)
-        if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(git_err):
+        if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(
+            git_err
+        ):
             test("compute_diff_for_commits dry_run", True, "Skipped: not enough commits in repo")
         else:
             raise
@@ -148,6 +155,7 @@ print("\n2.2 update_project_dry_run MCP tool...")
 try:
     from ast_rag.ast_rag_mcp import update_project_dry_run
     import inspect
+
     sig = inspect.signature(update_project_dry_run)
     params = list(sig.parameters.keys())
 
@@ -163,10 +171,14 @@ try:
             max_changed_nodes=10000,
         )
         test("  - returns dict with stats", "stats" in result)
-        test("  - has warning if exceeded", "warning" in result or True)  # May or may not have warning
+        test(
+            "  - has warning if exceeded", "warning" in result or True
+        )  # May or may not have warning
     except Exception as git_err:
         # Skip if not enough commits (e.g. only 1 commit in repo)
-        if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(git_err):
+        if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(
+            git_err
+        ):
             test("update_project_dry_run", True, "Skipped: not enough commits in repo")
             test("  - skipped (git error)", True, str(git_err)[:100])
         else:
@@ -181,6 +193,7 @@ print("\n2.3 max_changed_nodes in update_project...")
 try:
     from ast_rag.ast_rag_mcp import update_project
     import inspect
+
     sig = inspect.signature(update_project)
     params = list(sig.parameters.keys())
 
@@ -194,7 +207,7 @@ print("\n2.4 Skip statistics logging...")
 try:
     with open("ast_rag/graph_updater.py", "r") as f:
         content = f.read()
-    
+
     test("Skip ratio logged", "skip" in content.lower() or "skipped" in content.lower())
     test("Statistics logged", "logger.info" in content)
 except Exception as e:
@@ -210,8 +223,9 @@ print("=" * 80)
 print("\n3.1 metrics module exists...")
 try:
     from ast_rag import metrics
+
     test("metrics module imports", True)
-    
+
     # Check metrics are defined
     test("SEARCH_LATENCY histogram", hasattr(metrics, "SEARCH_LATENCY"))
     test("FIND_DEFINITION_LATENCY", hasattr(metrics, "FIND_DEFINITION_LATENCY"))
@@ -231,7 +245,7 @@ print("\n3.2 Metrics integrated in ast_rag_api...")
 try:
     with open("ast_rag/ast_rag_api.py", "r") as f:
         content = f.read()
-    
+
     test("Imports metrics", "from ast_rag.metrics import" in content)
     test("Uses track_latency", "@track_latency" in content or "track_latency(" in content)
 except Exception as e:
@@ -241,7 +255,7 @@ print("\n3.3 Metrics integrated in graph_updater...")
 try:
     with open("ast_rag/graph_updater.py", "r") as f:
         content = f.read()
-    
+
     test("Imports metrics", "from ast_rag.metrics import" in content)
     test("Updates SKIP_RATIO", "SKIP_RATIO.set" in content)
     test("Updates UPDATE_TOTAL", "UPDATE_TOTAL.labels" in content)
@@ -252,7 +266,7 @@ print("\n3.4 Grafana dashboard template...")
 try:
     dashboard_path = Path("docs/grafana_dashboard.json")
     test("grafana_dashboard.json exists", dashboard_path.exists())
-    
+
     if dashboard_path.exists():
         with open(dashboard_path, "r") as f:
             dashboard = json.load(f)
@@ -273,10 +287,10 @@ print("\n4.1 CLI module structure...")
 try:
     with open("ast_rag/cli.py", "r") as f:
         content = f.read()
-    
-    test("Has refs command", "@app.command(\"refs\")" in content or "def refs(" in content)
-    test("Has symbol-impact command", "@app.command(\"symbol-impact\")" in content)
-    test("Has call-graph command", "@app.command(\"call-graph\")" in content)
+
+    test("Has refs command", '@app.command("refs")' in content or "def refs(" in content)
+    test("Has symbol-impact command", '@app.command("symbol-impact")' in content)
+    test("Has call-graph command", '@app.command("call-graph")' in content)
 except Exception as e:
     test("CLI module structure", False, str(e))
 
@@ -287,9 +301,9 @@ try:
         capture_output=True,
         text=True,
         timeout=10,
-        cwd=PROJECT_ROOT
+        cwd=PROJECT_ROOT,
     )
-    
+
     test("CLI --help works", result.returncode == 0)
     if result.returncode == 0:
         test("  - Shows refs", "refs" in result.stdout)
@@ -305,7 +319,7 @@ try:
         capture_output=True,
         text=True,
         timeout=10,
-        cwd=PROJECT_ROOT
+        cwd=PROJECT_ROOT,
     )
 
     test("refs --help works", result.returncode == 0)
@@ -334,7 +348,7 @@ try:
         capture_output=True,
         text=True,
         timeout=10,
-        cwd=PROJECT_ROOT
+        cwd=PROJECT_ROOT,
     )
 
     test("symbol-impact --help works", result.returncode == 0)
@@ -356,7 +370,7 @@ try:
         capture_output=True,
         text=True,
         timeout=10,
-        cwd=PROJECT_ROOT
+        cwd=PROJECT_ROOT,
     )
 
     test("call-graph --help works", result.returncode == 0)
@@ -381,6 +395,7 @@ print("=" * 80)
 print("\n5.1 INJECTS in EdgeKind enum...")
 try:
     from ast_rag.models import EdgeKind
+
     test("INJECTS exists", hasattr(EdgeKind, "INJECTS"))
     test("  - value is 'INJECTS'", EdgeKind.INJECTS.value == "INJECTS")
 except Exception as e:
@@ -389,10 +404,10 @@ except Exception as e:
 print("\n5.2 DI queries in language_queries...")
 try:
     from ast_rag.language_queries import JAVA_QUERIES
-    
+
     test("di_fields query exists", "di_fields" in JAVA_QUERIES)
     test("di_constructors query exists", "di_constructors" in JAVA_QUERIES)
-    
+
     # Check query content
     if "di_fields" in JAVA_QUERIES:
         query = JAVA_QUERIES["di_fields"]
@@ -410,7 +425,7 @@ try:
     # Check method exists
     has_method = hasattr(ParserManager, "_extract_injects")
     test("_extract_injects method exists", has_method)
-    
+
     if has_method:
         # Check it's called in extract_edges
         with open("ast_rag/ast_parser.py", "r") as f:
@@ -423,6 +438,7 @@ except Exception as e:
 print("\n5.4 DI queries compile...")
 try:
     from ast_rag.services.parsing.parser_manager import ParserManager
+
     pm = ParserManager()
 
     java_queries = pm._compiled_queries.get("java", {})

--- a/tests/test_phase2.py
+++ b/tests/test_phase2.py
@@ -19,482 +19,488 @@ from pathlib import Path
 # Get project root directory dynamically
 PROJECT_ROOT = str(Path(__file__).parent.parent)
 
-print("=" * 80)
-print(" " * 20 + "PHASE 2 FUNCTIONAL TEST")
-print("=" * 80)
-print(f"Project root: {PROJECT_ROOT}")
-print(f"Python version: {sys.version}")
-print(f"Working directory: {os.getcwd()}")
-print()
 
-results = {"passed": 0, "failed": 0, "tests": []}
+def main():
+    print("=" * 80)
+    print(" " * 20 + "PHASE 2 FUNCTIONAL TEST")
+    print("=" * 80)
+    print(f"Project root: {PROJECT_ROOT}")
+    print(f"Python version: {sys.version}")
+    print(f"Working directory: {os.getcwd()}")
+    print()
 
+    results = {"passed": 0, "failed": 0, "tests": []}
 
-def test(name, condition, details=""):
-    status = "✅ PASS" if condition else "❌ FAIL"
-    results["tests"].append((name, status, details))
-    if condition:
-        results["passed"] += 1
-    else:
-        results["failed"] += 1
-    print(f"   {status}: {name}")
-    if details and not condition:
-        print(f"          {details}")
-
-
-# ============================================================================
-# TEST 1: StandardResult Model
-# ============================================================================
-print("\n" + "=" * 80)
-print("📋 ТЕСТ #1: StandardResult Output Format")
-print("=" * 80)
-
-print("\n1.1 StandardResult class exists...")
-try:
-    from ast_rag.models import StandardResult
-
-    result = StandardResult(
-        id="test123",
-        name="testMethod",
-        qualified_name="com.example.Test.testMethod",
-        kind="Method",
-        lang="java",
-        file_path="src/test.java",
-        start_line=10,
-        end_line=20,
-        score=0.85,
-        edge_type="CALLS",
-    )
-    test("StandardResult creation", True)
-    test("  - id field", result.id == "test123")
-    test("  - score field", result.score == 0.85)
-    test("  - edge_type field", result.edge_type == "CALLS")
-    test("  - to_markdown()", "testMethod" in result.to_markdown())
-except Exception as e:
-    test("StandardResult creation", False, str(e))
-
-print("\n1.2 ASTNode.to_standard_result()...")
-try:
-    from ast_rag.models import ASTNode, NodeKind, Language
-
-    node = ASTNode(
-        id="node1",
-        name="myFunction",
-        qualified_name="com.example.MyClass.myFunction",
-        kind=NodeKind.METHOD,
-        lang=Language.JAVA,
-        file_path="src/main.java",
-        start_line=42,
-        end_line=85,
-        start_byte=1000,  # Required field
-        end_byte=2000,  # Required field
-    )
-    std_result = node.to_standard_result(score=0.9)
-    test("to_standard_result() exists", std_result is not None)
-    test("  - score preserved", std_result.score == 0.9)
-    test("  - kind converted", std_result.kind == "Method")
-except Exception as e:
-    test("ASTNode.to_standard_result()", False, str(e))
-
-print("\n1.3 MCP tools return StandardResult...")
-try:
-    # Check if MCP tools use StandardResult
-    with open("ast_rag/ast_rag_mcp.py", "r") as f:
-        content = f.read()
-
-    test("find_references uses StandardResult", "StandardResult" in content)
-    test("semantic_search uses StandardResult", "StandardResult" in content)
-    test("find_callers uses StandardResult", "StandardResult" in content)
-    test("search_by_signature uses StandardResult", "StandardResult" in content)
-    test("get_diff uses StandardResult", "StandardResult" in content)
-except Exception as e:
-    test("MCP tools use StandardResult", False, str(e))
-
-# ============================================================================
-# TEST 2: Safety Net (Dry-Run + Limits)
-# ============================================================================
-print("\n" + "=" * 80)
-print("🛡️ ТЕСТ #2: Safety Net (Dry-Run + max_changed_nodes)")
-print("=" * 80)
-
-print("\n2.1 compute_diff_for_commits has dry_run...")
-try:
-    from ast_rag.services.graph_updater_service import compute_diff_for_commits
-    import inspect
-
-    sig = inspect.signature(compute_diff_for_commits)
-    params = list(sig.parameters.keys())
-
-    test("dry_run parameter exists", "dry_run" in params)
-    test("max_changed_nodes parameter exists", "max_changed_nodes" in params)
-
-    # Test dry_run mode
-    try:
-        result = compute_diff_for_commits(
-            PROJECT_ROOT,
-            "HEAD~1",
-            "HEAD",
-            dry_run=True,
-            max_changed_nodes=1000,
-        )
-        test("dry_run returns dict", isinstance(result, dict))
-        test("  - has 'stats' key", "stats" in result)
-        test("  - has 'exceeds_limit' key", "exceeds_limit" in result)
-    except Exception as git_err:
-        # Skip if not enough commits (e.g. only 1 commit in repo)
-        if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(
-            git_err
-        ):
-            test("compute_diff_for_commits dry_run", True, "Skipped: not enough commits in repo")
+    def test(name, condition, details=""):
+        status = "✅ PASS" if condition else "❌ FAIL"
+        results["tests"].append((name, status, details))
+        if condition:
+            results["passed"] += 1
         else:
-            raise
-except Exception as e:
-    test("compute_diff_for_commits dry_run", False, str(e))
+            results["failed"] += 1
+        print(f"   {status}: {name}")
+        if details and not condition:
+            print(f"          {details}")
 
-print("\n2.2 update_project_dry_run MCP tool...")
-try:
-    from ast_rag.ast_rag_mcp import update_project_dry_run
-    import inspect
+    # ============================================================================
+    # TEST 1: StandardResult Model
+    # ============================================================================
+    print("\n" + "=" * 80)
+    print("📋 ТЕСТ #1: StandardResult Output Format")
+    print("=" * 80)
 
-    sig = inspect.signature(update_project_dry_run)
-    params = list(sig.parameters.keys())
-
-    test("update_project_dry_run exists", True)
-    test("  - has max_changed_nodes param", "max_changed_nodes" in params)
-
-    # Try calling it (skip if not a git repo or commits don't exist)
+    print("\n1.1 StandardResult class exists...")
     try:
-        result = update_project_dry_run(
-            path=PROJECT_ROOT,
-            from_commit="HEAD~1",
-            to_commit="HEAD",
-            max_changed_nodes=10000,
+        from ast_rag.models import StandardResult
+
+        result = StandardResult(
+            id="test123",
+            name="testMethod",
+            qualified_name="com.example.Test.testMethod",
+            kind="Method",
+            lang="java",
+            file_path="src/test.java",
+            start_line=10,
+            end_line=20,
+            score=0.85,
+            edge_type="CALLS",
         )
-        test("  - returns dict with stats", "stats" in result)
-        test(
-            "  - has warning if exceeded", "warning" in result or True
-        )  # May or may not have warning
-    except Exception as git_err:
-        # Skip if not enough commits (e.g. only 1 commit in repo)
-        if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(
-            git_err
-        ):
-            test("update_project_dry_run", True, "Skipped: not enough commits in repo")
-            test("  - skipped (git error)", True, str(git_err)[:100])
-        else:
-            test("update_project_dry_run", False, str(git_err))
-            test("  - skipped (git error)", True, str(git_err)[:100])
-except ImportError as mcp_err:
-    test("update_project_dry_run MCP tool", False, f"MCP not installed: {mcp_err}")
-except Exception as e:
-    test("update_project_dry_run MCP tool", False, str(e))
+        test("StandardResult creation", True)
+        test("  - id field", result.id == "test123")
+        test("  - score field", result.score == 0.85)
+        test("  - edge_type field", result.edge_type == "CALLS")
+        test("  - to_markdown()", "testMethod" in result.to_markdown())
+    except Exception as e:
+        test("StandardResult creation", False, str(e))
 
-print("\n2.3 max_changed_nodes in update_project...")
-try:
-    from ast_rag.ast_rag_mcp import update_project
-    import inspect
+    print("\n1.2 ASTNode.to_standard_result()...")
+    try:
+        from ast_rag.models import ASTNode, NodeKind, Language
 
-    sig = inspect.signature(update_project)
-    params = list(sig.parameters.keys())
+        node = ASTNode(
+            id="node1",
+            name="myFunction",
+            qualified_name="com.example.MyClass.myFunction",
+            kind=NodeKind.METHOD,
+            lang=Language.JAVA,
+            file_path="src/main.java",
+            start_line=42,
+            end_line=85,
+            start_byte=1000,  # Required field
+            end_byte=2000,  # Required field
+        )
+        std_result = node.to_standard_result(score=0.9)
+        test("to_standard_result() exists", std_result is not None)
+        test("  - score preserved", std_result.score == 0.9)
+        test("  - kind converted", std_result.kind == "Method")
+    except Exception as e:
+        test("ASTNode.to_standard_result()", False, str(e))
 
-    test("update_project has max_changed_nodes", "max_changed_nodes" in params)
-except ImportError as mcp_err:
-    test("update_project max_changed_nodes", False, f"MCP not installed: {mcp_err}")
-except Exception as e:
-    test("update_project max_changed_nodes", False, str(e))
-
-print("\n2.4 Skip statistics logging...")
-try:
-    with open("ast_rag/graph_updater.py", "r") as f:
-        content = f.read()
-
-    test("Skip ratio logged", "skip" in content.lower() or "skipped" in content.lower())
-    test("Statistics logged", "logger.info" in content)
-except Exception as e:
-    test("Skip statistics logging", False, str(e))
-
-# ============================================================================
-# TEST 3: Monitoring Metrics
-# ============================================================================
-print("\n" + "=" * 80)
-print("📊 ТЕСТ #3: Monitoring (Prometheus Metrics)")
-print("=" * 80)
-
-print("\n3.1 metrics module exists...")
-try:
-    from ast_rag import metrics
-
-    test("metrics module imports", True)
-
-    # Check metrics are defined
-    test("SEARCH_LATENCY histogram", hasattr(metrics, "SEARCH_LATENCY"))
-    test("FIND_DEFINITION_LATENCY", hasattr(metrics, "FIND_DEFINITION_LATENCY"))
-    test("FIND_REFERENCES_LATENCY", hasattr(metrics, "FIND_REFERENCES_LATENCY"))
-    test("UPDATE_LATENCY histogram", hasattr(metrics, "UPDATE_LATENCY"))
-    test("SEARCH_TOTAL counter", hasattr(metrics, "SEARCH_TOTAL"))
-    test("UPDATE_TOTAL counter", hasattr(metrics, "UPDATE_TOTAL"))
-    test("GRAPH_NODES_TOTAL gauge", hasattr(metrics, "GRAPH_NODES_TOTAL"))
-    test("GRAPH_EDGES_TOTAL gauge", hasattr(metrics, "GRAPH_EDGES_TOTAL"))
-    test("SKIP_RATIO gauge", hasattr(metrics, "SKIP_RATIO"))
-    test("track_latency decorator", hasattr(metrics, "track_latency"))
-    test("start_metrics_server function", hasattr(metrics, "start_metrics_server"))
-except Exception as e:
-    test("metrics module", False, str(e))
-
-print("\n3.2 Metrics integrated in ast_rag_api...")
-try:
-    with open("ast_rag/ast_rag_api.py", "r") as f:
-        content = f.read()
-
-    test("Imports metrics", "from ast_rag.metrics import" in content)
-    test("Uses track_latency", "@track_latency" in content or "track_latency(" in content)
-except Exception as e:
-    test("Metrics in ast_rag_api", False, str(e))
-
-print("\n3.3 Metrics integrated in graph_updater...")
-try:
-    with open("ast_rag/graph_updater.py", "r") as f:
-        content = f.read()
-
-    test("Imports metrics", "from ast_rag.metrics import" in content)
-    test("Updates SKIP_RATIO", "SKIP_RATIO.set" in content)
-    test("Updates UPDATE_TOTAL", "UPDATE_TOTAL.labels" in content)
-except Exception as e:
-    test("Metrics in graph_updater", False, str(e))
-
-print("\n3.4 Grafana dashboard template...")
-try:
-    dashboard_path = Path("docs/grafana_dashboard.json")
-    test("grafana_dashboard.json exists", dashboard_path.exists())
-
-    if dashboard_path.exists():
-        with open(dashboard_path, "r") as f:
-            dashboard = json.load(f)
-        test("  - Valid JSON", True)
-        test("  - Has panels", "panels" in dashboard)  # Fixed: check root level
-        test("  - Panel count", len(dashboard.get("panels", [])) > 0)
-except Exception as e:
-    test("Grafana dashboard", False, str(e))
-
-# ============================================================================
-# TEST 4: CLI Commands
-# ============================================================================
-print("\n" + "=" * 80)
-print("💻 ТЕСТ #4: CLI Commands")
-print("=" * 80)
-
-print("\n4.1 CLI module structure...")
-try:
-    with open("ast_rag/cli.py", "r") as f:
-        content = f.read()
-
-    test("Has refs command", '@app.command("refs")' in content or "def refs(" in content)
-    test("Has symbol-impact command", '@app.command("symbol-impact")' in content)
-    test("Has call-graph command", '@app.command("call-graph")' in content)
-except Exception as e:
-    test("CLI module structure", False, str(e))
-
-print("\n4.2 Test CLI help...")
-try:
-    result = subprocess.run(
-        ["python", "-m", "ast_rag.cli", "--help"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        cwd=PROJECT_ROOT,
-    )
-
-    test("CLI --help works", result.returncode == 0)
-    if result.returncode == 0:
-        test("  - Shows refs", "refs" in result.stdout)
-        test("  - Shows symbol-impact", "symbol-impact" in result.stdout)
-        test("  - Shows call-graph", "call-graph" in result.stdout)
-except Exception as e:
-    test("CLI --help", False, str(e))
-
-print("\n4.3 Test refs command help...")
-try:
-    result = subprocess.run(
-        ["python", "-m", "ast_rag.cli", "refs", "--help"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        cwd=PROJECT_ROOT,
-    )
-
-    test("refs --help works", result.returncode == 0)
-    # Debug output
-    print(f"  Return code: {result.returncode}")
-    print(f"  Stdout length: {len(result.stdout)}")
-    print(f"  Stderr length: {len(result.stderr)}")
-    if result.returncode == 0:
-        test("  - Has --kind option", "--kind" in result.stdout)
-        test("  - Has --lang option", "--lang" in result.stdout)
-        test("  - Has --limit option", "--limit" in result.stdout)
-        # Show first 200 chars for debugging
-        print(f"  First 200 chars: {result.stdout[:200]}")
-    else:
-        # Print stderr for debugging
-        print(f"  STDERR: {result.stderr[:200]}")
-except ImportError as mcp_err:
-    test("refs --help", False, f"MCP not installed: {mcp_err}")
-except Exception as e:
-    test("refs --help", False, str(e))
-
-print("\n4.4 Test symbol-impact command help...")
-try:
-    result = subprocess.run(
-        ["python", "-m", "ast_rag.cli", "symbol-impact", "--help"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        cwd=PROJECT_ROOT,
-    )
-
-    test("symbol-impact --help works", result.returncode == 0)
-    print(f"  Return code: {result.returncode}")
-    print(f"  Stdout length: {len(result.stdout)}")
-    if result.returncode == 0:
-        test("  - Has --depth option", "--depth" in result.stdout)
-        test("  - Has --format option", "--format" in result.stdout)
-        print(f"  First 200 chars: {result.stdout[:200]}")
-except ImportError as mcp_err:
-    test("symbol-impact --help", False, f"MCP not installed: {mcp_err}")
-except Exception as e:
-    test("symbol-impact --help", False, str(e))
-
-print("\n4.5 Test call-graph command help...")
-try:
-    result = subprocess.run(
-        ["python", "-m", "ast_rag.cli", "call-graph", "--help"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        cwd=PROJECT_ROOT,
-    )
-
-    test("call-graph --help works", result.returncode == 0)
-    print(f"  Return code: {result.returncode}")
-    print(f"  Stdout length: {len(result.stdout)}")
-    if result.returncode == 0:
-        test("  - Has --direction option", "--direction" in result.stdout)
-        test("  - Has --depth option", "--depth" in result.stdout)
-        print(f"  First 200 chars: {result.stdout[:200]}")
-except ImportError as mcp_err:
-    test("call-graph --help", False, f"MCP not installed: {mcp_err}")
-except Exception as e:
-    test("call-graph --help", False, str(e))
-
-# ============================================================================
-# TEST 5: Java DI Analysis (INJECTS edges)
-# ============================================================================
-print("\n" + "=" * 80)
-print("☕ ТЕСТ #5: Java DI Analysis (INJECTS edges)")
-print("=" * 80)
-
-print("\n5.1 INJECTS in EdgeKind enum...")
-try:
-    from ast_rag.models import EdgeKind
-
-    test("INJECTS exists", hasattr(EdgeKind, "INJECTS"))
-    test("  - value is 'INJECTS'", EdgeKind.INJECTS.value == "INJECTS")
-except Exception as e:
-    test("INJECTS in EdgeKind", False, str(e))
-
-print("\n5.2 DI queries in language_queries...")
-try:
-    from ast_rag.language_queries import JAVA_QUERIES
-
-    test("di_fields query exists", "di_fields" in JAVA_QUERIES)
-    test("di_constructors query exists", "di_constructors" in JAVA_QUERIES)
-
-    # Check query content
-    if "di_fields" in JAVA_QUERIES:
-        query = JAVA_QUERIES["di_fields"]
-        test("  - di_fields has Autowired", "Autowired" in query)
-        test("  - di_fields has Inject", "Inject" in query)
-        test("  - di_fields has Resource", "Resource" in query)
-except Exception as e:
-    test("DI queries", False, str(e))
-
-print("\n5.3 _extract_injects method...")
-try:
-    from ast_rag.services.parsing.parser_manager import ParserManager
-    import inspect
-
-    # Check method exists
-    has_method = hasattr(ParserManager, "_extract_injects")
-    test("_extract_injects method exists", has_method)
-
-    if has_method:
-        # Check it's called in extract_edges
-        with open("ast_rag/ast_parser.py", "r") as f:
+    print("\n1.3 MCP tools return StandardResult...")
+    try:
+        # Check if MCP tools use StandardResult
+        with open("ast_rag/ast_rag_mcp.py", "r") as f:
             content = f.read()
-        test("  - Called in extract_edges", "_extract_injects(" in content)
-        test("  - Creates INJECTS edges", "EdgeKind.INJECTS" in content)
-except Exception as e:
-    test("_extract_injects method", False, str(e))
 
-print("\n5.4 DI queries compile...")
-try:
-    from ast_rag.services.parsing.parser_manager import ParserManager
+        test("find_references uses StandardResult", "StandardResult" in content)
+        test("semantic_search uses StandardResult", "StandardResult" in content)
+        test("find_callers uses StandardResult", "StandardResult" in content)
+        test("search_by_signature uses StandardResult", "StandardResult" in content)
+        test("get_diff uses StandardResult", "StandardResult" in content)
+    except Exception as e:
+        test("MCP tools use StandardResult", False, str(e))
 
-    pm = ParserManager()
+    # ============================================================================
+    # TEST 2: Safety Net (Dry-Run + Limits)
+    # ============================================================================
+    print("\n" + "=" * 80)
+    print("🛡️ ТЕСТ #2: Safety Net (Dry-Run + max_changed_nodes)")
+    print("=" * 80)
 
-    java_queries = pm._compiled_queries.get("java", {})
-    test("Java queries compiled", len(java_queries) > 0)
-    test("  - di_fields compiled", "di_fields" in java_queries)
-    test("  - di_constructors compiled", "di_constructors" in java_queries)
-except Exception as e:
-    test("DI queries compile", False, str(e))
+    print("\n2.1 compute_diff_for_commits has dry_run...")
+    try:
+        from ast_rag.services.graph_updater_service import compute_diff_for_commits
+        import inspect
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
-print("\n" + "=" * 80)
-print(" " * 30 + "ИТОГИ ТЕСТИРОВАНИЯ")
-print("=" * 80)
+        sig = inspect.signature(compute_diff_for_commits)
+        params = list(sig.parameters.keys())
 
-total = results["passed"] + results["failed"]
-pass_rate = (results["passed"] / total * 100) if total > 0 else 0
+        test("dry_run parameter exists", "dry_run" in params)
+        test("max_changed_nodes parameter exists", "max_changed_nodes" in params)
 
-print(f"\n📊 Всего тестов: {total}")
-print(f"   ✅ Пройдено: {results['passed']}")
-print(f"   ❌ Провалено: {results['failed']}")
-print(f"   📈 Процент успеха: {pass_rate:.1f}%")
+        # Test dry_run mode
+        try:
+            result = compute_diff_for_commits(
+                PROJECT_ROOT,
+                "HEAD~1",
+                "HEAD",
+                dry_run=True,
+                max_changed_nodes=1000,
+            )
+            test("dry_run returns dict", isinstance(result, dict))
+            test("  - has 'stats' key", "stats" in result)
+            test("  - has 'exceeds_limit' key", "exceeds_limit" in result)
+        except Exception as git_err:
+            # Skip if not enough commits (e.g. only 1 commit in repo)
+            if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(
+                git_err
+            ):
+                test(
+                    "compute_diff_for_commits dry_run", True, "Skipped: not enough commits in repo"
+                )
+            else:
+                raise
+    except Exception as e:
+        test("compute_diff_for_commits dry_run", False, str(e))
 
-print("\n📋 Детали по блокам:")
+    print("\n2.2 update_project_dry_run MCP tool...")
+    try:
+        from ast_rag.ast_rag_mcp import update_project_dry_run
+        import inspect
 
-# Group by block
-blocks = {
-    "StandardResult": 0,
-    "Safety Net": 0,
-    "Monitoring": 0,
-    "CLI": 0,
-    "DI Analysis": 0,
-}
+        sig = inspect.signature(update_project_dry_run)
+        params = list(sig.parameters.keys())
 
-for name, status, _ in results["tests"]:
-    if status == "✅ PASS":
-        if "StandardResult" in name:
-            blocks["StandardResult"] += 1
-        elif "Safety" in name or "dry_run" in name or "Skip" in name:
-            blocks["Safety Net"] += 1
-        elif "metrics" in name.lower() or "Metrics" in name or "Grafana" in name:
-            blocks["Monitoring"] += 1
-        elif "CLI" in name or "refs" in name or "symbol" in name or "call-graph" in name:
-            blocks["CLI"] += 1
-        elif "INJECTS" in name or "DI" in name:
-            blocks["DI Analysis"] += 1
+        test("update_project_dry_run exists", True)
+        test("  - has max_changed_nodes param", "max_changed_nodes" in params)
 
-for block, count in blocks.items():
-    print(f"   {block}: {count} тестов пройдено")
+        # Try calling it (skip if not a git repo or commits don't exist)
+        try:
+            result = update_project_dry_run(
+                path=PROJECT_ROOT,
+                from_commit="HEAD~1",
+                to_commit="HEAD",
+                max_changed_nodes=10000,
+            )
+            test("  - returns dict with stats", "stats" in result)
+            test(
+                "  - has warning if exceeded", "warning" in result or True
+            )  # May or may not have warning
+        except Exception as git_err:
+            # Skip if not enough commits (e.g. only 1 commit in repo)
+            if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(
+                git_err
+            ):
+                test("update_project_dry_run", True, "Skipped: not enough commits in repo")
+                test("  - skipped (git error)", True, str(git_err)[:100])
+            else:
+                test("update_project_dry_run", False, str(git_err))
+                test("  - skipped (git error)", True, str(git_err)[:100])
+    except ImportError as mcp_err:
+        test("update_project_dry_run MCP tool", False, f"MCP not installed: {mcp_err}")
+    except Exception as e:
+        test("update_project_dry_run MCP tool", False, str(e))
 
-print("\n" + "=" * 80)
-if results["failed"] == 0:
-    print(" " * 20 + "🎉 PHASE 2: 100% COMPLETE! 🎉")
-else:
-    print(" " * 25 + "⚠️ {results['failed']} тестов провалено")
-print("=" * 80)
+    print("\n2.3 max_changed_nodes in update_project...")
+    try:
+        from ast_rag.ast_rag_mcp import update_project
+        import inspect
 
-sys.exit(0 if results["failed"] == 0 else 1)
+        sig = inspect.signature(update_project)
+        params = list(sig.parameters.keys())
+
+        test("update_project has max_changed_nodes", "max_changed_nodes" in params)
+    except ImportError as mcp_err:
+        test("update_project max_changed_nodes", False, f"MCP not installed: {mcp_err}")
+    except Exception as e:
+        test("update_project max_changed_nodes", False, str(e))
+
+    print("\n2.4 Skip statistics logging...")
+    try:
+        with open("ast_rag/graph_updater.py", "r") as f:
+            content = f.read()
+
+        test("Skip ratio logged", "skip" in content.lower() or "skipped" in content.lower())
+        test("Statistics logged", "logger.info" in content)
+    except Exception as e:
+        test("Skip statistics logging", False, str(e))
+
+    # ============================================================================
+    # TEST 3: Monitoring Metrics
+    # ============================================================================
+    print("\n" + "=" * 80)
+    print("📊 ТЕСТ #3: Monitoring (Prometheus Metrics)")
+    print("=" * 80)
+
+    print("\n3.1 metrics module exists...")
+    try:
+        from ast_rag import metrics
+
+        test("metrics module imports", True)
+
+        # Check metrics are defined
+        test("SEARCH_LATENCY histogram", hasattr(metrics, "SEARCH_LATENCY"))
+        test("FIND_DEFINITION_LATENCY", hasattr(metrics, "FIND_DEFINITION_LATENCY"))
+        test("FIND_REFERENCES_LATENCY", hasattr(metrics, "FIND_REFERENCES_LATENCY"))
+        test("UPDATE_LATENCY histogram", hasattr(metrics, "UPDATE_LATENCY"))
+        test("SEARCH_TOTAL counter", hasattr(metrics, "SEARCH_TOTAL"))
+        test("UPDATE_TOTAL counter", hasattr(metrics, "UPDATE_TOTAL"))
+        test("GRAPH_NODES_TOTAL gauge", hasattr(metrics, "GRAPH_NODES_TOTAL"))
+        test("GRAPH_EDGES_TOTAL gauge", hasattr(metrics, "GRAPH_EDGES_TOTAL"))
+        test("SKIP_RATIO gauge", hasattr(metrics, "SKIP_RATIO"))
+        test("track_latency decorator", hasattr(metrics, "track_latency"))
+        test("start_metrics_server function", hasattr(metrics, "start_metrics_server"))
+    except Exception as e:
+        test("metrics module", False, str(e))
+
+    print("\n3.2 Metrics integrated in ast_rag_api...")
+    try:
+        with open("ast_rag/ast_rag_api.py", "r") as f:
+            content = f.read()
+
+        test("Imports metrics", "from ast_rag.metrics import" in content)
+        test("Uses track_latency", "@track_latency" in content or "track_latency(" in content)
+    except Exception as e:
+        test("Metrics in ast_rag_api", False, str(e))
+
+    print("\n3.3 Metrics integrated in graph_updater...")
+    try:
+        with open("ast_rag/graph_updater.py", "r") as f:
+            content = f.read()
+
+        test("Imports metrics", "from ast_rag.metrics import" in content)
+        test("Updates SKIP_RATIO", "SKIP_RATIO.set" in content)
+        test("Updates UPDATE_TOTAL", "UPDATE_TOTAL.labels" in content)
+    except Exception as e:
+        test("Metrics in graph_updater", False, str(e))
+
+    print("\n3.4 Grafana dashboard template...")
+    try:
+        dashboard_path = Path("docs/grafana_dashboard.json")
+        test("grafana_dashboard.json exists", dashboard_path.exists())
+
+        if dashboard_path.exists():
+            with open(dashboard_path, "r") as f:
+                dashboard = json.load(f)
+            test("  - Valid JSON", True)
+            test("  - Has panels", "panels" in dashboard)  # Fixed: check root level
+            test("  - Panel count", len(dashboard.get("panels", [])) > 0)
+    except Exception as e:
+        test("Grafana dashboard", False, str(e))
+
+    # ============================================================================
+    # TEST 4: CLI Commands
+    # ============================================================================
+    print("\n" + "=" * 80)
+    print("💻 ТЕСТ #4: CLI Commands")
+    print("=" * 80)
+
+    print("\n4.1 CLI module structure...")
+    try:
+        with open("ast_rag/cli.py", "r") as f:
+            content = f.read()
+
+        test("Has refs command", '@app.command("refs")' in content or "def refs(" in content)
+        test("Has symbol-impact command", '@app.command("symbol-impact")' in content)
+        test("Has call-graph command", '@app.command("call-graph")' in content)
+    except Exception as e:
+        test("CLI module structure", False, str(e))
+
+    print("\n4.2 Test CLI help...")
+    try:
+        result = subprocess.run(
+            ["python", "-m", "ast_rag.cli", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=PROJECT_ROOT,
+        )
+
+        test("CLI --help works", result.returncode == 0)
+        if result.returncode == 0:
+            test("  - Shows refs", "refs" in result.stdout)
+            test("  - Shows symbol-impact", "symbol-impact" in result.stdout)
+            test("  - Shows call-graph", "call-graph" in result.stdout)
+    except Exception as e:
+        test("CLI --help", False, str(e))
+
+    print("\n4.3 Test refs command help...")
+    try:
+        result = subprocess.run(
+            ["python", "-m", "ast_rag.cli", "refs", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=PROJECT_ROOT,
+        )
+
+        test("refs --help works", result.returncode == 0)
+        # Debug output
+        print(f"  Return code: {result.returncode}")
+        print(f"  Stdout length: {len(result.stdout)}")
+        print(f"  Stderr length: {len(result.stderr)}")
+        if result.returncode == 0:
+            test("  - Has --kind option", "--kind" in result.stdout)
+            test("  - Has --lang option", "--lang" in result.stdout)
+            test("  - Has --limit option", "--limit" in result.stdout)
+            # Show first 200 chars for debugging
+            print(f"  First 200 chars: {result.stdout[:200]}")
+        else:
+            # Print stderr for debugging
+            print(f"  STDERR: {result.stderr[:200]}")
+    except ImportError as mcp_err:
+        test("refs --help", False, f"MCP not installed: {mcp_err}")
+    except Exception as e:
+        test("refs --help", False, str(e))
+
+    print("\n4.4 Test symbol-impact command help...")
+    try:
+        result = subprocess.run(
+            ["python", "-m", "ast_rag.cli", "symbol-impact", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=PROJECT_ROOT,
+        )
+
+        test("symbol-impact --help works", result.returncode == 0)
+        print(f"  Return code: {result.returncode}")
+        print(f"  Stdout length: {len(result.stdout)}")
+        if result.returncode == 0:
+            test("  - Has --depth option", "--depth" in result.stdout)
+            test("  - Has --format option", "--format" in result.stdout)
+            print(f"  First 200 chars: {result.stdout[:200]}")
+    except ImportError as mcp_err:
+        test("symbol-impact --help", False, f"MCP not installed: {mcp_err}")
+    except Exception as e:
+        test("symbol-impact --help", False, str(e))
+
+    print("\n4.5 Test call-graph command help...")
+    try:
+        result = subprocess.run(
+            ["python", "-m", "ast_rag.cli", "call-graph", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=PROJECT_ROOT,
+        )
+
+        test("call-graph --help works", result.returncode == 0)
+        print(f"  Return code: {result.returncode}")
+        print(f"  Stdout length: {len(result.stdout)}")
+        if result.returncode == 0:
+            test("  - Has --direction option", "--direction" in result.stdout)
+            test("  - Has --depth option", "--depth" in result.stdout)
+            print(f"  First 200 chars: {result.stdout[:200]}")
+    except ImportError as mcp_err:
+        test("call-graph --help", False, f"MCP not installed: {mcp_err}")
+    except Exception as e:
+        test("call-graph --help", False, str(e))
+
+    # ============================================================================
+    # TEST 5: Java DI Analysis (INJECTS edges)
+    # ============================================================================
+    print("\n" + "=" * 80)
+    print("☕ ТЕСТ #5: Java DI Analysis (INJECTS edges)")
+    print("=" * 80)
+
+    print("\n5.1 INJECTS in EdgeKind enum...")
+    try:
+        from ast_rag.models import EdgeKind
+
+        test("INJECTS exists", hasattr(EdgeKind, "INJECTS"))
+        test("  - value is 'INJECTS'", EdgeKind.INJECTS.value == "INJECTS")
+    except Exception as e:
+        test("INJECTS in EdgeKind", False, str(e))
+
+    print("\n5.2 DI queries in language_queries...")
+    try:
+        from ast_rag.language_queries import JAVA_QUERIES
+
+        test("di_fields query exists", "di_fields" in JAVA_QUERIES)
+        test("di_constructors query exists", "di_constructors" in JAVA_QUERIES)
+
+        # Check query content
+        if "di_fields" in JAVA_QUERIES:
+            query = JAVA_QUERIES["di_fields"]
+            test("  - di_fields has Autowired", "Autowired" in query)
+            test("  - di_fields has Inject", "Inject" in query)
+            test("  - di_fields has Resource", "Resource" in query)
+    except Exception as e:
+        test("DI queries", False, str(e))
+
+    print("\n5.3 _extract_injects method...")
+    try:
+        from ast_rag.services.parsing.parser_manager import ParserManager
+        import inspect
+
+        # Check method exists
+        has_method = hasattr(ParserManager, "_extract_injects")
+        test("_extract_injects method exists", has_method)
+
+        if has_method:
+            # Check it's called in extract_edges
+            with open("ast_rag/ast_parser.py", "r") as f:
+                content = f.read()
+            test("  - Called in extract_edges", "_extract_injects(" in content)
+            test("  - Creates INJECTS edges", "EdgeKind.INJECTS" in content)
+    except Exception as e:
+        test("_extract_injects method", False, str(e))
+
+    print("\n5.4 DI queries compile...")
+    try:
+        from ast_rag.services.parsing.parser_manager import ParserManager
+
+        pm = ParserManager()
+
+        java_queries = pm._compiled_queries.get("java", {})
+        test("Java queries compiled", len(java_queries) > 0)
+        test("  - di_fields compiled", "di_fields" in java_queries)
+        test("  - di_constructors compiled", "di_constructors" in java_queries)
+    except Exception as e:
+        test("DI queries compile", False, str(e))
+
+    # ============================================================================
+    # SUMMARY
+    # ============================================================================
+    print("\n" + "=" * 80)
+    print(" " * 30 + "ИТОГИ ТЕСТИРОВАНИЯ")
+    print("=" * 80)
+
+    total = results["passed"] + results["failed"]
+    pass_rate = (results["passed"] / total * 100) if total > 0 else 0
+
+    print(f"\n📊 Всего тестов: {total}")
+    print(f"   ✅ Пройдено: {results['passed']}")
+    print(f"   ❌ Провалено: {results['failed']}")
+    print(f"   📈 Процент успеха: {pass_rate:.1f}%")
+
+    print("\n📋 Детали по блокам:")
+
+    # Group by block
+    blocks = {
+        "StandardResult": 0,
+        "Safety Net": 0,
+        "Monitoring": 0,
+        "CLI": 0,
+        "DI Analysis": 0,
+    }
+
+    for name, status, _ in results["tests"]:
+        if status == "✅ PASS":
+            if "StandardResult" in name:
+                blocks["StandardResult"] += 1
+            elif "Safety" in name or "dry_run" in name or "Skip" in name:
+                blocks["Safety Net"] += 1
+            elif "metrics" in name.lower() or "Metrics" in name or "Grafana" in name:
+                blocks["Monitoring"] += 1
+            elif "CLI" in name or "refs" in name or "symbol" in name or "call-graph" in name:
+                blocks["CLI"] += 1
+            elif "INJECTS" in name or "DI" in name:
+                blocks["DI Analysis"] += 1
+
+    for block, count in blocks.items():
+        print(f"   {block}: {count} тестов пройдено")
+
+    print("\n" + "=" * 80)
+    if results["failed"] == 0:
+        print(" " * 20 + "🎉 PHASE 2: 100% COMPLETE! 🎉")
+    else:
+        print(" " * 25 + "⚠️ {results['failed']} тестов провалено")
+    print("=" * 80)
+
+    sys.exit(0 if results["failed"] == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stack_trace.py
+++ b/tests/test_stack_trace.py
@@ -31,9 +31,10 @@ from ast_rag.stack_trace.parsers import (
 # MODEL TESTS
 # ============================================================================
 
+
 class TestStackFrame:
     """Tests for StackFrame model."""
-    
+
     def test_create_basic_frame(self):
         """Test creating a basic stack frame."""
         frame = StackFrame(
@@ -43,7 +44,7 @@ class TestStackFrame:
             line_number=42,
             language=Language.PYTHON,
         )
-        
+
         assert frame.frame_index == 0
         assert frame.function_name == "my_function"
         assert frame.file_path == "/path/to/file.py"
@@ -51,7 +52,7 @@ class TestStackFrame:
         assert frame.language == Language.PYTHON
         assert frame.class_name is None
         assert frame.code_snippet is None
-    
+
     def test_create_method_frame(self):
         """Test creating a method frame with class name."""
         frame = StackFrame(
@@ -63,10 +64,10 @@ class TestStackFrame:
             language=Language.JAVA,
             frame_type=FrameType.METHOD_CALL,
         )
-        
+
         assert frame.class_name == "MyClass"
         assert frame.frame_type == FrameType.METHOD_CALL
-    
+
     def test_frame_to_dict(self):
         """Test converting frame to dictionary."""
         frame = StackFrame(
@@ -76,9 +77,9 @@ class TestStackFrame:
             line_number=10,
             language=Language.PYTHON,
         )
-        
+
         d = frame.to_dict()
-        
+
         assert d["frame_index"] == 0
         assert d["function_name"] == "test_func"
         assert d["file_path"] == "test.py"
@@ -88,7 +89,7 @@ class TestStackFrame:
 
 class TestRootCause:
     """Tests for RootCause model."""
-    
+
     def test_create_root_cause(self):
         """Test creating root cause analysis."""
         rc = RootCause(
@@ -101,18 +102,18 @@ class TestRootCause:
             confidence=0.85,
             related_frames=[0, 1],
         )
-        
+
         assert rc.error_type == "ValueError"
         assert rc.confidence == 0.85
         assert len(rc.related_frames) == 2
-    
+
     def test_root_cause_defaults(self):
         """Test root cause default values."""
         rc = RootCause(
             error_type="Error",
             error_message="Something went wrong",
         )
-        
+
         assert rc.severity == "medium"
         assert rc.confidence == 0.0
         assert rc.likely_cause is None
@@ -121,7 +122,7 @@ class TestRootCause:
 
 class TestStackTraceReport:
     """Tests for StackTraceReport model."""
-    
+
     def test_create_report(self):
         """Test creating a complete report."""
         frame = StackFrame(
@@ -131,7 +132,7 @@ class TestStackTraceReport:
             line_number=1,
             language=Language.PYTHON,
         )
-        
+
         report = StackTraceReport(
             error_type="ValueError",
             message="Invalid input",
@@ -140,11 +141,11 @@ class TestStackTraceReport:
             total_frames=1,
             mapped_frames=1,
         )
-        
+
         assert report.error_type == "ValueError"
         assert len(report.call_chain) == 1
         assert report.total_frames == 1
-    
+
     def test_report_to_json(self):
         """Test report JSON serialization."""
         report = StackTraceReport(
@@ -152,15 +153,16 @@ class TestStackTraceReport:
             message="Test",
             language=Language.PYTHON,
         )
-        
+
         import json
+
         json_str = report.to_json()
         data = json.loads(json_str)
-        
+
         assert data["error_type"] == "Error"
         assert data["message"] == "Test"
         assert data["language"] == "python"
-    
+
     def test_report_to_markdown(self):
         """Test report Markdown rendering."""
         frame = StackFrame(
@@ -170,7 +172,7 @@ class TestStackTraceReport:
             line_number=10,
             language=Language.PYTHON,
         )
-        
+
         report = StackTraceReport(
             error_type="ValueError",
             message="Test error",
@@ -179,9 +181,9 @@ class TestStackTraceReport:
             total_frames=1,
             mapped_frames=0,
         )
-        
+
         md = report.to_markdown()
-        
+
         assert "# Stack Trace Analysis Report" in md
         assert "ValueError" in md
         assert "test.py:10" in md
@@ -191,13 +193,14 @@ class TestStackTraceReport:
 # PARSER TESTS
 # ============================================================================
 
+
 class TestPythonParser:
     """Tests for Python stack trace parser."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.parser = PythonParser()
-    
+
     def test_detect_language(self):
         """Test Python language detection."""
         trace = """
@@ -207,7 +210,7 @@ Traceback (most recent call last):
 ValueError: error
 """
         assert self.parser.detect_language(trace) == Language.PYTHON
-    
+
     def test_extract_error_info(self):
         """Test error type and message extraction."""
         trace = """
@@ -216,10 +219,10 @@ Traceback (most recent call last):
 ValueError: Invalid input value
 """
         error_type, message = self.parser.extract_error_info(trace)
-        
+
         assert error_type == "ValueError"
         assert message == "Invalid input value"
-    
+
     def test_parse_simple_trace(self):
         """Test parsing a simple Python stack trace."""
         trace = """
@@ -231,14 +234,14 @@ Traceback (most recent call last):
 ValueError: error
 """
         frames = self.parser.parse(trace)
-        
+
         assert len(frames) == 2
         assert frames[0].function_name == "<module>"
         assert frames[0].file_path == "main.py"
         assert frames[0].line_number == 42
         assert frames[1].function_name == "process"
         assert frames[1].file_path == "processor.py"
-    
+
     def test_parse_with_class_method(self):
         """Test parsing trace with class.method pattern."""
         trace = """
@@ -250,17 +253,17 @@ Traceback (most recent call last):
 AttributeError: error
 """
         frames = self.parser.parse(trace)
-        
+
         assert len(frames) >= 1
 
 
 class TestCppParser:
     """Tests for C++ stack trace parser."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.parser = CppParser()
-    
+
     def test_detect_language(self):
         """Test C++ language detection."""
         trace = """
@@ -268,7 +271,7 @@ class TestCppParser:
 #1  0x00007fff5fbff700 in main at main.cpp:15
 """
         assert self.parser.detect_language(trace) == Language.CPP
-    
+
     def test_extract_error_info(self):
         """Test C++ error extraction."""
         trace = """
@@ -276,9 +279,9 @@ terminate called after throwing an instance of 'std::out_of_range'
   what(): vector::_M_range_check
 """
         error_type, message = self.parser.extract_error_info(trace)
-        
+
         assert "std::" in error_type or error_type == "std::exception"
-    
+
     def test_parse_gdb_style(self):
         """Test parsing GDB-style stack trace."""
         trace = """
@@ -296,14 +299,14 @@ Stack trace:
         assert frames[-1].function_name == "main"
         assert frames[-1].file_path == "main.cpp"
         assert any("processData" in f.function_name for f in frames)
-    
+
     def test_parse_with_class_method(self):
         """Test parsing C++ method calls."""
         trace = """
 #0  0x12345678 in MyClass::myMethod(int) at file.cpp:42
 """
         frames = self.parser.parse(trace)
-        
+
         assert len(frames) == 1
         assert frames[0].class_name == "MyClass"
         # Function name may include parameters in C++ traces
@@ -312,11 +315,11 @@ Stack trace:
 
 class TestJavaParser:
     """Tests for Java stack trace parser."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.parser = JavaParser()
-    
+
     def test_detect_language(self):
         """Test Java language detection."""
         trace = """
@@ -324,7 +327,7 @@ java.lang.NullPointerException
     at com.example.MyClass.method(MyClass.java:42)
 """
         assert self.parser.detect_language(trace) == Language.JAVA
-    
+
     def test_extract_error_info(self):
         """Test Java error extraction."""
         trace = """
@@ -332,10 +335,10 @@ java.lang.NullPointerException: Cannot invoke method on null
     at com.example.Test.method(Test.java:10)
 """
         error_type, message = self.parser.extract_error_info(trace)
-        
+
         assert error_type == "java.lang.NullPointerException"
         assert "null" in message.lower()
-    
+
     def test_parse_simple_trace(self):
         """Test parsing simple Java stack trace."""
         trace = """
@@ -344,13 +347,13 @@ java.lang.Exception: Error
     at com.example.Main.main(Main.java:15)
 """
         frames = self.parser.parse(trace)
-        
+
         assert len(frames) == 2
         assert frames[0].function_name == "getUser"
         assert frames[0].class_name == "UserService"
         assert frames[0].file_path == "UserService.java"
         assert frames[0].line_number == 42
-    
+
     def test_parse_with_caused_by(self):
         """Test parsing Java trace with 'Caused by:'."""
         trace = """
@@ -360,18 +363,18 @@ Caused by: java.lang.IllegalArgumentException: Invalid
     at com.example.Test.validate(Test.java:20)
 """
         frames = self.parser.parse(trace)
-        
+
         # Should parse frames from both the main exception and caused by
         assert len(frames) >= 2
 
 
 class TestRustParser:
     """Tests for Rust stack trace parser."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.parser = RustParser()
-    
+
     def test_detect_language(self):
         """Test Rust language detection."""
         trace = """
@@ -379,17 +382,17 @@ thread 'main' panicked at 'index out of bounds', src/main.rs:42:5
 stack backtrace:
 """
         assert self.parser.detect_language(trace) == Language.RUST
-    
+
     def test_extract_error_info(self):
         """Test Rust error extraction."""
         trace = """
 thread 'main' panicked at 'index out of bounds: len is 3 but index is 5', src/main.rs:42:5
 """
         error_type, message = self.parser.extract_error_info(trace)
-        
+
         assert error_type == "panic"
         assert "index out of bounds" in message
-    
+
     def test_parse_backtrace(self):
         """Test parsing Rust backtrace."""
         trace = """
@@ -403,14 +406,14 @@ stack backtrace:
               at src/main.rs:10:1
 """
         frames = self.parser.parse(trace)
-        
+
         # Should have panic frame plus backtrace frames
         assert len(frames) >= 1
 
 
 class TestParserFactory:
     """Tests for StackTraceParserFactory."""
-    
+
     def test_detect_python(self):
         """Test auto-detection of Python traces."""
         trace = """
@@ -419,10 +422,10 @@ Traceback (most recent call last):
 ValueError: error
 """
         parser, frames, language = StackTraceParserFactory.detect_and_parse(trace)
-        
+
         assert language == Language.PYTHON
         assert isinstance(parser, PythonParser)
-    
+
     def test_detect_java(self):
         """Test auto-detection of Java traces."""
         trace = """
@@ -430,37 +433,37 @@ java.lang.Exception
     at com.example.Test.method(Test.java:10)
 """
         parser, frames, language = StackTraceParserFactory.detect_and_parse(trace)
-        
+
         assert language == Language.JAVA
         assert isinstance(parser, JavaParser)
-    
+
     def test_detect_cpp(self):
         """Test auto-detection of C++ traces."""
         trace = """
 #0  0x12345678 in func() at file.cpp:42
 """
         parser, frames, language = StackTraceParserFactory.detect_and_parse(trace)
-        
+
         assert language == Language.CPP
         assert isinstance(parser, CppParser)
-    
+
     def test_detect_rust(self):
         """Test auto-detection of Rust traces."""
         trace = """
 thread 'main' panicked at 'error', src/main.rs:42:5
 """
         parser, frames, language = StackTraceParserFactory.detect_and_parse(trace)
-        
+
         assert language == Language.RUST
         assert isinstance(parser, RustParser)
-    
+
     def test_get_parser_by_language(self):
         """Test getting parser by explicit language."""
         python_parser = StackTraceParserFactory.get_parser(Language.PYTHON)
         cpp_parser = StackTraceParserFactory.get_parser(Language.CPP)
         java_parser = StackTraceParserFactory.get_parser(Language.JAVA)
         rust_parser = StackTraceParserFactory.get_parser(Language.RUST)
-        
+
         assert isinstance(python_parser, PythonParser)
         assert isinstance(cpp_parser, CppParser)
         assert isinstance(java_parser, JavaParser)
@@ -471,49 +474,56 @@ thread 'main' panicked at 'error', src/main.rs:42:5
 # INTEGRATION TESTS (with mocked API)
 # ============================================================================
 
+
 class TestStackTraceServiceMocked:
     """Integration tests with mocked dependencies."""
-    
+
     def test_service_initialization(self):
         """Test service can be initialized."""
         # This test would require Neo4j and Qdrant running
         # For now, just verify imports work
         from ast_rag.stack_trace import StackTraceService
+
         assert StackTraceService is not None
-    
+
     def test_full_analysis_flow_mocked(self):
         """Test full analysis flow with mocked API."""
+
         # Mock the API components
         class MockSession:
             def __enter__(self):
                 return self
+
             def __exit__(self, *args):
                 pass
+
             def run(self, *args, **kwargs):
                 # Return empty result for Cypher queries
                 class MockResult:
                     def single(self):
                         return None
+
                 return MockResult()
-        
+
         class MockDriver:
             def session(self):
                 return MockSession()
+
             def close(self):
                 pass
-        
+
         class MockEmbedding:
             def search(self, query, limit=10, **kwargs):
                 return []
-        
+
         from ast_rag.stack_trace import StackTraceService
-        
+
         # Create service with mocks
         service = StackTraceService(
             driver=MockDriver(),
             embedding_manager=MockEmbedding(),
         )
-        
+
         # Test parsing
         trace = """
 Traceback (most recent call last):
@@ -523,7 +533,7 @@ ValueError: error
 """
         # This would normally call the API, but with mocks it should handle gracefully
         report = service.analyze(trace)
-        
+
         assert report.error_type == "ValueError"
         assert report.language == Language.PYTHON
         assert report.total_frames >= 1
@@ -533,45 +543,46 @@ ValueError: error
 # EXAMPLE VALIDATION TESTS
 # ============================================================================
 
+
 class TestExamples:
     """Tests to validate example stack traces can be parsed."""
-    
+
     def test_python_example(self):
         """Test parsing Python example."""
         from ast_rag.stack_trace.examples import PYTHON_STACKTRACE_EXAMPLE
-        
+
         parser = PythonParser()
         frames = parser.parse(PYTHON_STACKTRACE_EXAMPLE)
-        
+
         assert len(frames) >= 1
         assert any("process_data" in f.function_name for f in frames)
-    
+
     def test_java_example(self):
         """Test parsing Java example."""
         from ast_rag.stack_trace.examples import JAVA_STACKTRACE_EXAMPLE
-        
+
         parser = JavaParser()
         frames = parser.parse(JAVA_STACKTRACE_EXAMPLE)
-        
+
         assert len(frames) >= 1
         assert any("UserService" in (f.class_name or "") for f in frames)
-    
+
     def test_cpp_example(self):
         """Test parsing C++ example."""
         from ast_rag.stack_trace.examples import CPP_STACKTRACE_EXAMPLE
-        
+
         parser = CppParser()
         frames = parser.parse(CPP_STACKTRACE_EXAMPLE)
-        
+
         assert len(frames) >= 1
-    
+
     def test_rust_example(self):
         """Test parsing Rust example."""
         from ast_rag.stack_trace.examples import RUST_STACKTRACE_EXAMPLE
-        
+
         parser = RustParser()
         frames = parser.parse(RUST_STACKTRACE_EXAMPLE)
-        
+
         assert len(frames) >= 1
 
 

--- a/tests/test_stack_trace.py
+++ b/tests/test_stack_trace.py
@@ -8,14 +8,12 @@ Tests cover:
 """
 
 import pytest
-from pathlib import Path
 
 from ast_rag.stack_trace.models import (
     Language,
     FrameType,
     StackFrame,
     RootCause,
-    SimilarIssue,
     StackTraceReport,
 )
 from ast_rag.stack_trace.parsers import (

--- a/tests/test_standard_result.py
+++ b/tests/test_standard_result.py
@@ -1,6 +1,6 @@
 def test_standard_result_creation():
     from ast_rag.models import StandardResult
-    
+
     result = StandardResult(
         id="test123",
         name="processRequest",

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -29,7 +29,7 @@ class TestNodeSummary:
             node_id="test123",
             summary="Test function summary",
         )
-        
+
         assert summary.node_id == "test123"
         assert summary.summary == "Test function summary"
         assert summary.inputs == []
@@ -68,7 +68,7 @@ class TestNodeSummary:
             tags=["async", "io", "validated"],
             model_used="qwen2.5-coder:14b",
         )
-        
+
         assert len(summary.inputs) == 2
         assert len(summary.outputs) == 1
         assert len(summary.side_effects) == 2
@@ -84,9 +84,9 @@ class TestNodeSummary:
             summary="Test summary",
             complexity=ComplexityLevel.LOW,
         )
-        
+
         result = summary.to_dict()
-        
+
         assert isinstance(result, dict)
         assert result["node_id"] == "test789"
         assert result["summary"] == "Test summary"
@@ -103,9 +103,9 @@ class TestNodeSummary:
             complexity=ComplexityLevel.LOW,
             tags=["pure", "getter"],
         )
-        
+
         md = summary.to_markdown()
-        
+
         assert "## Summary:" in md
         assert "Markdown test summary" in md
         assert "### Inputs" in md
@@ -122,7 +122,7 @@ class TestSummaryPromptTemplate:
     def test_prompt_template_structure(self):
         """Test that prompt template has required sections."""
         prompt = SUMMARY_PROMPT_TEMPLATE
-        
+
         assert "Signature" in prompt
         assert "Source Code" in prompt
         assert "Context" in prompt
@@ -141,7 +141,7 @@ class TestSummaryPromptTemplate:
             calls_context="- com.example.other_func",
             callers_context="- com.example.caller_func",
         )
-        
+
         assert "def test_func(x: int) -> str" in formatted
         assert "```python" in formatted
         assert "com.example.other_func" in formatted
@@ -154,7 +154,7 @@ class TestSummarizerService:
     def test_init_defaults(self):
         """Test default initialization."""
         service = SummarizerService()
-        
+
         assert service._base_url == "http://localhost:11434/v1"
         assert service._model == "qwen2.5-coder:14b"
         assert service._api_key == "ollama"
@@ -170,7 +170,7 @@ class TestSummarizerService:
             timeout=60,
             cache_enabled=False,
         )
-        
+
         assert service._base_url == "http://custom:8000/v1"
         assert service._model == "test-model"
         assert service._api_key == "test-key"
@@ -180,15 +180,15 @@ class TestSummarizerService:
     def test_compute_code_hash(self):
         """Test code hash computation."""
         service = SummarizerService()
-        
+
         code1 = "def test(): pass"
         code2 = "def test(): pass"
         code3 = "def other(): pass"
-        
+
         hash1 = service._compute_code_hash(code1)
         hash2 = service._compute_code_hash(code2)
         hash3 = service._compute_code_hash(code3)
-        
+
         assert hash1 == hash2  # Same code = same hash
         assert hash1 != hash3  # Different code = different hash
         assert len(hash1) == 24  # Hash is 24 chars
@@ -196,20 +196,20 @@ class TestSummarizerService:
     def test_cache_operations(self):
         """Test cache save and load."""
         service = SummarizerService(cache_enabled=True)
-        
+
         # Create a test summary
         summary = NodeSummary(
             node_id="cache_test",
             summary="Cached summary",
         )
-        
+
         # Cache it
         code_hash = service._compute_code_hash("test code")
         service._cache_summary("cache_test", code_hash, summary)
-        
+
         # Retrieve from cache
         cached = service._get_cached_summary("cache_test", code_hash)
-        
+
         assert cached is not None
         assert cached.node_id == "cache_test"
         assert cached.summary == "Cached summary"
@@ -217,27 +217,27 @@ class TestSummarizerService:
     def test_cache_invalidates_on_code_change(self):
         """Test that cache is invalidated when code changes."""
         service = SummarizerService(cache_enabled=True)
-        
+
         summary = NodeSummary(
             node_id="invalidate_test",
             summary="Old summary",
         )
-        
+
         # Cache with old code hash
         old_hash = service._compute_code_hash("old code")
         service._cache_summary("invalidate_test", old_hash, summary)
-        
+
         # Try to retrieve with new code hash
         new_hash = service._compute_code_hash("new code")
         cached = service._get_cached_summary("invalidate_test", new_hash)
-        
+
         assert cached is None  # Cache miss due to code change
 
     def test_parse_llm_response_plain_json(self):
         """Test parsing plain JSON response."""
         service = SummarizerService()
-        
-        response = '''
+
+        response = """
         {
             "summary": "Test summary",
             "inputs": [],
@@ -248,18 +248,18 @@ class TestSummarizerService:
             "complexity": "low",
             "tags": []
         }
-        '''
-        
+        """
+
         parsed = service._parse_llm_response(response)
-        
+
         assert parsed["summary"] == "Test summary"
         assert parsed["complexity"] == "low"
 
     def test_parse_llm_response_markdown_wrapped(self):
         """Test parsing Markdown-wrapped JSON response."""
         service = SummarizerService()
-        
-        response = '''
+
+        response = """
         ```json
         {
             "summary": "Markdown wrapped summary",
@@ -272,10 +272,10 @@ class TestSummarizerService:
             "tags": ["test"]
         }
         ```
-        '''
-        
+        """
+
         parsed = service._parse_llm_response(response)
-        
+
         assert parsed["summary"] == "Markdown wrapped summary"
         assert parsed["complexity"] == "medium"
         assert "test" in parsed["tags"]
@@ -284,7 +284,7 @@ class TestSummarizerService:
     async def test_call_llm_async(self):
         """Test async LLM call (mocked)."""
         service = SummarizerService()
-        
+
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "choices": [
@@ -296,12 +296,12 @@ class TestSummarizerService:
             ]
         }
         mock_response.raise_for_status = MagicMock()
-        
-        with patch.object(service, '_client') as mock_client:
+
+        with patch.object(service, "_client") as mock_client:
             mock_client.post = AsyncMock(return_value=mock_response)
-            
+
             result = await service._call_llm_async("Test prompt")
-            
+
             assert "Mock summary" in result
 
 
@@ -330,13 +330,13 @@ class TestSummaryCacheEntry:
             node_id="entry_test",
             summary="Test",
         )
-        
+
         entry = SummaryCacheEntry(
             node_id="entry_test",
             code_hash="abc123",
             summary=summary,
         )
-        
+
         assert entry.node_id == "entry_test"
         assert entry.code_hash == "abc123"
         assert entry.summary == summary

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -6,18 +6,16 @@ Run with: pytest tests/test_summarizer.py -v
 
 from __future__ import annotations
 
-import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from ast_rag.summarizer import (
+from ast_rag.services.summarizer_service import (
     SummarizerService,
     NodeSummary,
     ComplexityLevel,
     SummaryCacheEntry,
     SUMMARY_PROMPT_TEMPLATE,
 )
-from ast_rag.models import ASTNode, NodeKind, Language
 
 
 class TestNodeSummary:

--- a/tests/test_update_project_dry_run.py
+++ b/tests/test_update_project_dry_run.py
@@ -12,7 +12,9 @@ def test_update_project_dry_run():
         assert "warning" in result or "warning" not in result  # Depends on repo size
     except Exception as git_err:
         # Skip if not enough commits (e.g. only 1 commit in repo)
-        if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(git_err):
+        if "not enough parent commits" in str(git_err) or "did not resolve to an object" in str(
+            git_err
+        ):
             print(f"  Skipped: not enough commits in repo ({git_err})")
             return  # Test passes by skipping
         raise

--- a/tests/test_update_project_dry_run.py
+++ b/tests/test_update_project_dry_run.py
@@ -1,3 +1,8 @@
+import pytest
+
+from neo4j.exceptions import ServiceUnavailable
+
+
 def test_update_project_dry_run():
     """Test the update_project_dry_run MCP tool."""
     from ast_rag.ast_rag_mcp import update_project_dry_run
@@ -24,7 +29,11 @@ def test_search_by_signature_format():
     """Test the search_by_signature MCP tool returns StandardResult format."""
     from ast_rag.ast_rag_mcp import search_by_signature
 
-    results = search_by_signature("*(int, String)", lang="java", limit=5)
+    try:
+        results = search_by_signature("*(int, String)", lang="java", limit=5)
+    except ServiceUnavailable as exc:
+        pytest.skip(f"Neo4j unavailable for integration-style search test: {exc}")
+
     assert isinstance(results, list)
     if results:
         assert "id" in results[0]


### PR DESCRIPTION
## Description

This PR started as repo-wide Ruff cleanup, but the cleanup exposed older breakage from the March refactor. I expanded the branch to restore compatibility with the current architecture and get CI back to a green baseline without changing core indexing or query behavior.

## What changed

- fixed all pre-existing Ruff lint errors and applied `ruff format`
- wrapped `tests/test_phase2.py` in a `__main__` guard so pytest collection no longer exits the runner
- restored `ast_rag.repositories.queries` used by `graph_updater_service`
- fixed `ast_rag.services.parsing` package initialization order to avoid a circular import during import-time setup
- added compatibility shims for legacy public module paths moved by the refactor:
  - `ast_rag.ast_rag_api`
  - `ast_rag.ast_rag_mcp`
  - `ast_rag.graph_updater`
  - `ast_rag.language_queries`
  - `ast_rag.parse_cache`
  - `ast_rag.summarizer`
  - `ast_rag.watcher`
- updated stale tests to import the refactored module locations
- made the Neo4j-dependent search format test skip locally when Neo4j is unavailable
- ignored the generated summary cache artifact `.ast_rag_summary_cache.json`
- updated GitHub Actions checkout to fetch full history so commit-diff tests can resolve both revisions in pull request runs

## Why this fits the current architecture

- keeps the refactored package layout as the source of truth
- uses thin shims only to preserve old public import paths still referenced by tests, docs, and examples
- avoids changing core graph/indexing logic beyond restoring the missing `queries.py` helper module expected by the current service layer

## Verification

- `ruff check ast_rag/`
- `ruff format --check ast_rag/ tests/`
- `pytest tests/ -v --tb=short`
  - local result: `95 passed, 1 skipped`
  - the skipped test is the Neo4j integration-style search test when no local Neo4j is running; CI provides Neo4j service, so it should execute there
- GitHub Actions `test` check passed on this PR: https://github.com/lexasub/raged/actions/runs/23445517499

## Notes

- no maintainer review comments were present yet when I refreshed this branch
- this PR is now broader than the original lint-only description, so the title/body were updated to match the actual branch contents
